### PR TITLE
Fix for deserializing sets of complex objects

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/RepositoryAwareJacksonModule.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/RepositoryAwareJacksonModule.java
@@ -282,12 +282,10 @@ public class RepositoryAwareJacksonModule extends SimpleModule implements Initia
               }
 
               if((tok = jp.nextToken()) == JsonToken.START_ARRAY) {
-				// advance past the start_array token
-				jp.nextToken();
-                do {
+				while((tok = jp.nextToken()) != JsonToken.END_ARRAY) {
                   Object cval = jp.readValueAs(attrMeta.elementType());
                   c.add(cval);
-                } while((tok = jp.nextToken()) != JsonToken.END_ARRAY);
+                }
 
                 val = c;
 
@@ -303,12 +301,10 @@ public class RepositoryAwareJacksonModule extends SimpleModule implements Initia
               }
 
               if((tok = jp.nextToken()) == JsonToken.START_ARRAY) {
-				// advance past the start_array token
-				jp.nextToken();
-                do {
+				while((tok = jp.nextToken()) != JsonToken.END_ARRAY) {
                   Object sval = jp.readValueAs(attrMeta.elementType());
                   s.add(sval);
-                } while((tok = jp.nextToken()) != JsonToken.END_ARRAY);
+                }
 
                 val = s;
 


### PR DESCRIPTION
I ran into an issue doing a POST with an entity that contained collections of complex types using @ElementCollection. RepositoryAwareJacksonModule.deserialize() was not advancing the token past the START_ARRAY before trying to read the first entry of the array. Here is a fix for the issue.
