### PR TITLE
Update spring-data-rest-repository/src/main/java/org/springframework/dat...

### DIFF
--- a/spring-data-rest-repository/src/main/java/org/springframework/data/rest/repository/jpa/JpaEntityMetadata.java
+++ b/spring-data-rest-repository/src/main/java/org/springframework/data/rest/repository/jpa/JpaEntityMetadata.java
@@ -61,7 +61,8 @@ public class JpaEntityMetadata implements EntityMetadata<JpaAttributeMetadata> {
         if(repositories.hasRepositoryFor(attrType)) {
           linkedAttributes.put(name, new JpaAttributeMetadata(entityType, attr));
         } else {
-          if((attr instanceof SingularAttribute && ((SingularAttribute)attr).isId())) {
+          if(((attr instanceof SingularAttribute && ((SingularAttribute)attr).isId())
+            && (null == fieldResourceAnno || !StringUtils.hasText(fieldResourceAnno.path()))) {
             // Don't export the id attribute
             continue;
           } else if(((attr instanceof SingularAttribute) && ((SingularAttribute)attr).isVersion())


### PR DESCRIPTION
Jon,

Submitting a pull request to have the same logic that you applied for the "Version" value in JpaEntityMetadata added to the Id value.  If the Id value is annotated with @RestResource(path...), then the id would be written.  

I was hoping to have this ability in order to maintain backwards compatibility with my old existing api, and I thought that it might be useful for others rather than just deploying my forked version internally.

Thanks,

Mike
