### PR TITLE
DATAREST-56 - RepositoryRestHandlerMapping now uses lowest precedence.

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryRestHandlerMapping.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryRestHandlerMapping.java
@@ -32,7 +32,7 @@ public class RepositoryRestHandlerMapping extends RequestMappingHandlerMapping {
   private Set<String>              repositoryNames     = new HashSet<String>();
 
   public RepositoryRestHandlerMapping() {
-    setOrder(Ordered.HIGHEST_PRECEDENCE);
+    setOrder(Ordered.LOWEST_PRECEDENCE);
   }
 
   @SuppressWarnings({"unchecked"})


### PR DESCRIPTION
Invoke super constructor with Ordered.LOWEST_PRECEDENCE to allow custom controller implementations hook into the URI space managed by the RepositoryRestController.
