### PR TITLE
Remove memory leaks of RepositoryRestMvcConfig

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.ImportResource;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.convert.support.ConfigurableConversionService;
 import org.springframework.data.repository.support.DomainClassConverter;
+import org.springframework.data.repository.support.Repositories;
 import org.springframework.data.rest.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.convert.ISO8601DateConverter;
 import org.springframework.data.rest.convert.UUIDConverter;
@@ -145,9 +146,9 @@ public class RepositoryRestMvcConfiguration {
 	 *
 	 * @throws Exception
 	 */
-	@Bean public DomainObjectMerger domainObjectMerger() throws Exception {
+	@Bean public DomainObjectMerger domainObjectMerger(Repositories repositories) throws Exception {
 		return new DomainObjectMerger(
-				repositories().getObject(),
+				repositories,
 				defaultConversionService()
 		);
 	}
@@ -159,13 +160,13 @@ public class RepositoryRestMvcConfiguration {
 	 *
 	 * @throws Exception
 	 */
-	@Bean public RepositoryController repositoryController() throws Exception {
+	@Bean public RepositoryController repositoryController(Repositories repositories, EntityLinks entityLinks) throws Exception {
 		return new RepositoryController(
-				repositories().getObject(),
+				repositories,
 				config(),
 				domainClassConverter(),
 				defaultConversionService(),
-				entityLinks()
+				entityLinks
 		);
 	}
 
@@ -176,13 +177,13 @@ public class RepositoryRestMvcConfiguration {
 	 *
 	 * @throws Exception
 	 */
-	@Bean public RepositoryEntityController repositoryEntityController() throws Exception {
+	@Bean public RepositoryEntityController repositoryEntityController(Repositories repositories, EntityLinks entityLinks) throws Exception {
 		return new RepositoryEntityController(
-				repositories().getObject(),
+				repositories,
 				config(),
 				domainClassConverter(),
 				defaultConversionService(),
-				entityLinks()
+				entityLinks
 		);
 	}
 
@@ -193,13 +194,13 @@ public class RepositoryRestMvcConfiguration {
 	 *
 	 * @throws Exception
 	 */
-	@Bean public RepositoryPropertyReferenceController propertyReferenceController() throws Exception {
+	@Bean public RepositoryPropertyReferenceController propertyReferenceController(Repositories repositories, EntityLinks entityLinks) throws Exception {
 		return new RepositoryPropertyReferenceController(
-				repositories().getObject(),
+				repositories,
 				config(),
 				domainClassConverter(),
 				defaultConversionService(),
-				entityLinks()
+				entityLinks
 		);
 	}
 
@@ -210,13 +211,13 @@ public class RepositoryRestMvcConfiguration {
 	 *
 	 * @throws Exception
 	 */
-	@Bean public RepositorySearchController repositorySearchController() throws Exception {
+	@Bean public RepositorySearchController repositorySearchController(Repositories repositories, EntityLinks entityLinks) throws Exception {
 		return new RepositorySearchController(
-				repositories().getObject(),
+				repositories,
 				config(),
 				domainClassConverter(),
 				defaultConversionService(),
-				entityLinks()
+				entityLinks
 		);
 	}
 
@@ -273,8 +274,8 @@ public class RepositoryRestMvcConfiguration {
 	 *
 	 * @throws Exception
 	 */
-	@Bean public EntityLinks entityLinks() throws Exception {
-		return new RepositoryEntityLinks(repositories().getObject(), config());
+	@Bean public EntityLinks entityLinks(Repositories repositories) throws Exception {
+		return new RepositoryEntityLinks(repositories, config());
 	}
 
 	/**


### PR DESCRIPTION
If you call getObject() directly on a FactoryBean it will create a memory leak because the bean is not managed by the application context.

Therefore I removed all calls to getObject() and let the context insert the dependency.

I tested this with my application using Tomcat 6 and jProfiler 6's Telemetry view. After a stop or undeploy the non-heap memory usage goes back down when running the GC.
