### PR TITLE
Fixing bug disabling JSON inline serialization for non managed types

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/PersistentEntityJackson2Module.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/PersistentEntityJackson2Module.java
@@ -299,10 +299,6 @@ public class PersistentEntityJackson2Module extends SimpleModule implements Init
 
 						PersistentProperty property = association.getInverse();
 
-						if (!mappings.isMapped(property)) {
-							return;
-						}
-
 						if (maybeAddAssociationLink(builder, mappings, property, links)) {
 							return;
 						}


### PR DESCRIPTION
Hi,

In previous versions, I used to annotate some JPA repositories with exported=false in order to avoid Link creation in an entity. In such case, these entities was just serialized through standard JSON serialization like { "property":"value"}

The following patch is bypassing an optimization which is actually breaking this comportment.

Thanks a lot for your amazing work done so far !

Romain
