### PR TITLE
DATAREST-107 Respect @RestResource exported flag

### DIFF
--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/mapping/ResourceMappings.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/mapping/ResourceMappings.java
@@ -34,7 +34,7 @@ import org.springframework.util.Assert;
 /**
  * Central abstraction obtain {@link ResourceMetadata} and {@link ResourceMapping} instances for domain types and
  * repositories.
- * 
+ *
  * @author Oliver Gierke
  */
 public class ResourceMappings implements Iterable<ResourceMetadata> {
@@ -48,7 +48,7 @@ public class ResourceMappings implements Iterable<ResourceMetadata> {
 	/**
 	 * Creates a new {@link ResourceMappings} using the given {@link RepositoryRestConfiguration} and {@link Repositories}
 	 * .
-	 * 
+	 *
 	 * @param config
 	 * @param repositories
 	 */
@@ -59,7 +59,7 @@ public class ResourceMappings implements Iterable<ResourceMetadata> {
 	/**
 	 * Creates a new {@link ResourceMappings} from the given {@link RepositoryRestConfiguration}, {@link Repositories} and
 	 * {@link RelProvider}.
-	 * 
+	 *
 	 * @param config must not be {@literal null}.
 	 * @param repositories must not be {@literal null}.
 	 * @param relProvider must not be {@literal null}.
@@ -77,7 +77,7 @@ public class ResourceMappings implements Iterable<ResourceMetadata> {
 
 	/**
 	 * Returns a {@link ResourceMetadata} for the given type if available.
-	 * 
+	 *
 	 * @param type must not be {@literal null}.
 	 * @return
 	 */
@@ -109,7 +109,7 @@ public class ResourceMappings implements Iterable<ResourceMetadata> {
 
 	/**
 	 * Returns the {@link ResourceMapping}s for the search resources of the given type.
-	 * 
+	 *
 	 * @param type must not be {@literal null}.
 	 * @return
 	 */
@@ -133,7 +133,11 @@ public class ResourceMappings implements Iterable<ResourceMetadata> {
 
 		if (resourceMapping.isExported()) {
 			for (Method queryMethod : repositoryInformation.getQueryMethods()) {
-				mappings.add(new RepositoryMethodResourceMapping(queryMethod, resourceMapping));
+				RepositoryMethodResourceMapping methodMapping = new RepositoryMethodResourceMapping(
+						queryMethod, resourceMapping);
+				if(methodMapping.isExported()) {
+					mappings.add(methodMapping);
+				}
 			}
 		}
 
@@ -145,7 +149,7 @@ public class ResourceMappings implements Iterable<ResourceMetadata> {
 
 	/**
 	 * Returns whether we have a {@link ResourceMapping} for the given type and it is exported.
-	 * 
+	 *
 	 * @param type
 	 * @return
 	 */
@@ -161,7 +165,7 @@ public class ResourceMappings implements Iterable<ResourceMetadata> {
 
 	/**
 	 * Returns whether we have a {@link ResourceMapping} for the given type.
-	 * 
+	 *
 	 * @param type must not be {@literal null}.
 	 * @return
 	 */
@@ -182,7 +186,7 @@ public class ResourceMappings implements Iterable<ResourceMetadata> {
 		return false;
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.rest.core.mapping.ResourceMetadataProvider#getMappingFor(org.springframework.data.mapping.PersistentProperty)
 	 */
@@ -190,7 +194,7 @@ public class ResourceMappings implements Iterable<ResourceMetadata> {
 		return getMappingFor(property.getActualType());
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.rest.core.mapping.ResourceMetadataProvider#hasMappingFor(org.springframework.data.mapping.PersistentProperty)
 	 */
@@ -200,7 +204,7 @@ public class ResourceMappings implements Iterable<ResourceMetadata> {
 		return metadata != null && metadata.isExported();
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see java.lang.Iterable#iterator()
 	 */


### PR DESCRIPTION
Update ResourceMappings to respect the @RestResource exported flag
when used on a repository method.
