### PR TITLE
Changed Neo4J version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
   sdJpaVersion = "1.5.0.BUILD-SNAPSHOT"
   sdMongoVersion = "1.4.0.BUILD-SNAPSHOT"
   sdGemfireVersion = "1.3.3.BUILD-SNAPSHOT"
-  sdNeo4jVersion = "2.4.0.BUILD-SNAPSHOT"
+  sdNeo4jVersion = "2.3.2.RELEASE"
 
   // Libraries
   jacksonVersion = "2.2.2"


### PR DESCRIPTION
```
- Changed Neo4J 2.4.0 to 2.3.2 to allow download and build due to 401 when
  trying to fetch Neo4J
```
