### PR TITLE
Fix for DATAREST-216, DATAREST-217 and ReflectionRepositoryInvoker performance improvement (DATAREST-218)

### DIFF
--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/invoke/CrudRepositoryInvoker.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/invoke/CrudRepositoryInvoker.java
@@ -30,6 +30,12 @@ import org.springframework.data.repository.core.RepositoryInformation;
  * @author Oliver Gierke
  */
 class CrudRepositoryInvoker extends ReflectionRepositoryInvoker {
+	/*
+	 * NOTE: FindOne is not called directly as this will bypass any annotated version in the more 
+	 * derived class since the 'findOne(Serializable)' version will be called instead of any 
+	 * overridden, covariant argument version. This is due to the fact that we are providing a parameter
+	 * of type 'Serializable'.
+	 */
 
 	private final CrudRepository<Object, Serializable> repository;
 
@@ -73,15 +79,6 @@ class CrudRepositoryInvoker extends ReflectionRepositoryInvoker {
 	@Override
 	public Iterable<Object> invokeFindAll(Pageable pageable) {
 		return repository.findAll();
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.rest.core.invoke.RepositoryInvoker#invokeFindOne(java.io.Serializable)
-	 */
-	@Override
-	public Object invokeFindOne(Serializable id) {
-		return repository.findOne(convertId(id));
 	}
 
 	/*

--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/invoke/CrudVTable.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/invoke/CrudVTable.java
@@ -1,0 +1,92 @@
+package org.springframework.data.rest.core.invoke;
+
+import java.lang.reflect.Method;
+
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * A 'VTable' for CRUD methods supported by
+ * {@link org.springframework.data.repository.PagingAndSortingRepository} or
+ * {@link org.springframework.data.repository.CrudRepository}.
+ * 
+ * This class contains a method delegate for each CRUD method. 
+ * 
+ * @author Nick Weedon
+ */
+public class CrudVTable {
+
+	/**
+	 * Simple delegate class that uses reflection to invoke
+	 * the assigned method on the assigned repository. 
+	 * 
+	 * @author Nick Weedon
+	 */
+	public static class CrudMethodDelegate {
+		private final Object repository;
+		private Method method;
+
+		/**
+		 * Construct a delegate pointing to a repository CRUD method.
+		 * @param repository The repository to invoke against
+		 * @param method The CRUD method to call 
+		 * 
+		 * @author Nick Weedon
+		 */
+		public CrudMethodDelegate(Object repository, Method method) {
+			this.repository = repository;
+			this.method = method;
+		}
+
+		/**
+		 * Call the repository CRUD method 
+		 * using {@link org.springframework.util.ReflectionUtils#invokeMethod(Method, Object, Object...)}
+		 * 
+		 * @param arguments The method arguments
+		 * 
+		 * @author Nick Weedon
+		 */
+		@SuppressWarnings("unchecked")
+		public <T> T invoke(Object... arguments) {
+			return (T) ReflectionUtils.invokeMethod(method, repository, arguments);
+		}
+	};
+
+	// The CRUD method delegates
+	private CrudMethodDelegate saveMethod; 
+	private CrudMethodDelegate deleteMethod; 
+	private CrudMethodDelegate findOneMethod;
+	private CrudMethodDelegate findAllPagableMethod;
+	private CrudMethodDelegate findAllSortMethod;
+	
+	// Getters/Setters for CRUD method delegates
+	public CrudVTable.CrudMethodDelegate getSaveMethod() {
+		return saveMethod;
+	}
+	public void setSaveMethod(CrudVTable.CrudMethodDelegate saveMethod) {
+		this.saveMethod = saveMethod;
+	}
+	public CrudVTable.CrudMethodDelegate getDeleteMethod() {
+		return deleteMethod;
+	}
+	public void setDeleteMethod(CrudVTable.CrudMethodDelegate deleteMethod) {
+		this.deleteMethod = deleteMethod;
+	}
+	public CrudVTable.CrudMethodDelegate getFindOneMethod() {
+		return findOneMethod;
+	}
+	public void setFindOneMethod(CrudVTable.CrudMethodDelegate findOneMethod) {
+		this.findOneMethod = findOneMethod;
+	}
+	public CrudVTable.CrudMethodDelegate getFindAllPagableMethod() {
+		return findAllPagableMethod;
+	}
+	public void setFindAllPagableMethod(CrudVTable.CrudMethodDelegate findAllPagableMethod) {
+		this.findAllPagableMethod = findAllPagableMethod;
+	}
+	public CrudVTable.CrudMethodDelegate getFindAllSortMethod() {
+		return findAllSortMethod;
+	}
+	public void setFindAllSortMethod(CrudVTable.CrudMethodDelegate findAllSortMethod) {
+		this.findAllSortMethod = findAllSortMethod;
+	}
+}

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryEntityController.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryEntityController.java
@@ -117,10 +117,14 @@ class RepositoryEntityController extends AbstractRepositoryRestController implem
 			throw new ResourceNotFoundException();
 		}
 
-		if (pageable != null) {
-			results = repoMethodInvoker.invokeFindAll(pageable);
+		if(!repoMethodInvoker.exposesFindAll()) {
+			results = Collections.emptyList();
 		} else {
-			results = repoMethodInvoker.invokeFindAll(sort);
+			if (pageable != null) {
+				results = repoMethodInvoker.invokeFindAll(pageable);
+			} else {
+				results = repoMethodInvoker.invokeFindAll(sort);
+			}
 		}
 
 		ResourceMetadata metadata = request.getResourceMetadata();


### PR DESCRIPTION
DATAREST-216 - Removed CrudRepositoryInvoker#invokeFindOne(Serializable id) method override as this will cause the findOne(Serializable id) method to be called instead of any existing, more specific methods. This in turn bypasses any AOP proxying of the more specific method.

DATAREST-217 - Fixed issue where all entities were still being shown when the 'findAll' method is explicitly not exported. The RepositoryEntityController#listEntities now checks to see if the method is exposed and returns an empty object array if it is not. This is a more appropriate place for this behavior than the ReflectionRepositoryInvoker since this is a REST presentation issue.

DATAREST-218 - Improved the performance of the ReflectionRepositoryInvoker by introducing a 'VTable' (i.e. a object that holds delegates to each CRUD method). This allows all of the 'method choosing' behavior to be performed during the initialization of the repository instead of occurring on a 'per CRUD method call' basis. The absence of a delegate demarcates a method that is either missing from the underlying repository or that is explicitly not exported. This avoids a further reflection call each time to check for the 'exported' annotation.
