### PR TITLE
DATAREST-217

### DIFF
--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/invoke/ReflectionRepositoryInvoker.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/invoke/ReflectionRepositoryInvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.springframework.data.rest.core.invoke;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -41,6 +40,7 @@ import org.springframework.util.StringUtils;
  * Base {@link RepositoryInvoker} using reflection to invoke methods on Spring Data Repositories.
  * 
  * @author Oliver Gierke
+ * @author Nick Weedon
  */
 class ReflectionRepositoryInvoker implements RepositoryInvoker {
 
@@ -96,11 +96,6 @@ class ReflectionRepositoryInvoker implements RepositoryInvoker {
 	 */
 	@Override
 	public Iterable<Object> invokeFindAll(Pageable pageable) {
-
-		if (!exposesFindAll()) {
-			return Collections.emptyList();
-		}
-
 		Method method = methods.getFindAllMethod();
 		Class<?>[] types = method.getParameterTypes();
 

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryEntityController.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryEntityController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Jon Brisbin
  * @author Oliver Gierke
+ * @author Nick Weedon
  */
 @RepositoryRestController
 class RepositoryEntityController extends AbstractRepositoryRestController implements ApplicationEventPublisherAware {
@@ -117,12 +118,14 @@ class RepositoryEntityController extends AbstractRepositoryRestController implem
 			throw new ResourceNotFoundException();
 		}
 
-		if (pageable != null) {
-			results = repoMethodInvoker.invokeFindAll(pageable);
-		} else {
-			results = repoMethodInvoker.invokeFindAll(sort);
-		}
-
+        if(!repoMethodInvoker.exposesFindAll()) {
+            results = Collections.emptyList();
+        } else if (pageable != null) {
+	       results = repoMethodInvoker.invokeFindAll(pageable);
+        } else {
+	        results = repoMethodInvoker.invokeFindAll(sort);
+        }
+		
 		ResourceMetadata metadata = request.getResourceMetadata();
 		SearchResourceMappings searchMappings = metadata.getSearchResourceMappings();
 

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/jpa/Animal.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/jpa/Animal.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.webmvc.jpa;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+/**
+ * @author Nick Weedon
+ */
+@Entity
+public class Animal {
+	@Id
+	@GeneratedValue
+	Long id;
+	String name;
+	
+	public Animal(String name) {
+		this.name = name;
+	}
+}

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/jpa/AnimalRepository.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/jpa/AnimalRepository.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.webmvc.jpa;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.rest.core.annotation.RestResource;
+
+/**
+ * @author Nick Weedon
+ */
+@RestResource(rel = "animal", path = "animal")
+public interface AnimalRepository extends PagingAndSortingRepository<Animal, Long> {
+	@Override
+	@RestResource(exported = false)
+	Page<Animal> findAll(Pageable pageable);
+}

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaWebTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaWebTests.java
@@ -51,6 +51,7 @@ import com.jayway.jsonpath.JsonPath;
  * 
  * @author Oliver Gierke
  * @author Greg Turnquist
+ * @author Nick Weedon
  */
 @Transactional
 @ContextConfiguration(classes = JpaRepositoryConfig.class)
@@ -58,6 +59,7 @@ public class JpaWebTests extends AbstractWebIntegrationTests {
 
 	private static final MediaType TEXT_URI_LIST = MediaType.valueOf("text/uri-list");
 	static final String LINK_TO_SIBLINGS_OF = "$._embedded..[?(@.firstName == '%s')]._links.siblings.href[0]";
+	static final String EMPTY_JSON_OBJECT_STRING = "{ }";
 
 	@Autowired TestDataPopulator loader;
 	@Autowired ResourceMappings mappings;
@@ -190,6 +192,16 @@ public class JpaWebTests extends AbstractWebIntegrationTests {
 		String href = assertHasJsonPathValue(String.format(LINK_TO_SIBLINGS_OF, "Billy Bob"), response);
 
 		mvc.perform(get(href)).andExpect(status().isOk());
+	}
+	
+	@Test
+	/**
+	 * @see DATAREST-217
+	 */
+	public void doesNotExposeUnexportedAnimalEntities() throws Exception {
+		MockHttpServletResponse response = mvc.perform(get("/animal")).andReturn().getResponse();
+		
+		assertEquals("Expected no entities to be returned.", EMPTY_JSON_OBJECT_STRING, response.getContentAsString());
 	}
 
 	/**

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/jpa/TestDataPopulator.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/jpa/TestDataPopulator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.rest.webmvc.jpa;
 
 import java.util.Arrays;
@@ -7,6 +22,7 @@ import org.springframework.stereotype.Component;
 
 /**
  * @author Jon Brisbin
+ * @author Nick Weedon
  */
 @Component
 public class TestDataPopulator {
@@ -15,15 +31,17 @@ public class TestDataPopulator {
 	private final OrderRepository orders;
 	private final AuthorRepository authorRepository;
 	private final BookRepository books;
+	private final AnimalRepository animals;
 
 	@Autowired
 	public TestDataPopulator(PersonRepository people, OrderRepository orders, AuthorRepository authors,
-			BookRepository books) {
+			BookRepository books, AnimalRepository animals) {
 
 		this.people = people;
 		this.orders = orders;
 		this.authorRepository = authors;
 		this.books = books;
+		this.animals = animals;
 	}
 
 	public void populateRepositories() {
@@ -31,6 +49,7 @@ public class TestDataPopulator {
 		populatePeople();
 		populateOrders();
 		populateAuthorsAndBooks();
+		populateAnimals();
 	}
 
 	private void populateAuthorsAndBooks() {
@@ -83,4 +102,14 @@ public class TestDataPopulator {
 		people.save(Arrays.asList(john, jane));
 	}
 
+	private void populateAnimals() {
+		if (animals.count() != 0) {
+			return;
+		}
+
+		animals.save(new Animal("Tiger"));
+		animals.save(new Animal("Horse"));
+		animals.save(new Animal("Sarah Jessica Parker"));
+	}
+	
 }


### PR DESCRIPTION
Fixed issue where all entities were still being shown when the 'findAll' method is explicitly not exported. The RepositoryEntityController#listEntities now checks to see if the method is exposed and returns an empty object array if it is not. This is a more appropriate place for this behavior than the ReflectionRepositoryInvoker since this is a REST presentation issue.

Pull request includes fix implementation and test case