### PR TITLE
Datarest 216

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
 		<springdata.mongodb>1.4.0.BUILD-SNAPSHOT</springdata.mongodb>
 		<springdata.neo4j>3.0.0.BUILD-SNAPSHOT</springdata.neo4j>
 		<springdata.gemfire>1.3.3.RELEASE</springdata.gemfire>
+		<springsecurity>3.2.0.RELEASE</springsecurity>
 
 		<hibernate.version>4.2.0.Final</hibernate.version>
 
@@ -119,6 +120,20 @@
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
 			<version>2.2.8</version>
+			<scope>test</scope>
+		</dependency>
+
+    <dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-core</artifactId>
+			<version>${springsecurity}</version>
+			<scope>test</scope>
+		</dependency>
+
+    <dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-config</artifactId>
+			<version>${springsecurity}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/invoke/CrudRepositoryInvoker.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/invoke/CrudRepositoryInvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.data.repository.core.RepositoryInformation;
  * to avoid reflection overhead introduced by the base class if we know we work with a {@link CrudRepository}.
  * 
  * @author Oliver Gierke
+ * @author Nick Weedon
  */
 class CrudRepositoryInvoker extends ReflectionRepositoryInvoker {
 
@@ -48,6 +49,9 @@ class CrudRepositoryInvoker extends ReflectionRepositoryInvoker {
 		this.repository = repository;
 	}
 
+	// Note that findOne should not be called directly as this causes problems with JDK based proxying
+	// See DATAREST-216
+	
 	/**
 	 * Invokes the method equivalent to {@link CrudRepository#findAll()}.
 	 * 
@@ -73,15 +77,6 @@ class CrudRepositoryInvoker extends ReflectionRepositoryInvoker {
 	@Override
 	public Iterable<Object> invokeFindAll(Pageable pageable) {
 		return repository.findAll();
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.rest.core.invoke.RepositoryInvoker#invokeFindOne(java.io.Serializable)
-	 */
-	@Override
-	public Object invokeFindOne(Serializable id) {
-		return repository.findOne(convertId(id));
 	}
 
 	/*

--- a/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/RepositoryTestsConfig.java
+++ b/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/RepositoryTestsConfig.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.rest.core;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -5,6 +20,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.ImportResource;
 import org.springframework.data.repository.support.DomainClassConverter;
 import org.springframework.data.repository.support.Repositories;
 import org.springframework.data.rest.core.UriDomainClassConverter;
@@ -17,9 +33,11 @@ import org.springframework.format.support.DefaultFormattingConversionService;
 
 /**
  * @author Jon Brisbin
+ * @author Nick Weedon
  */
 @Configuration
 @Import({ JpaRepositoryConfig.class })
+@ImportResource("testSecurity.xml")
 public class RepositoryTestsConfig {
 
 	@Autowired private ApplicationContext appCtx;

--- a/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/domain/jpa/Agent.java
+++ b/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/domain/jpa/Agent.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.core.domain.jpa;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+/**
+ * @author Nick Weedon
+ */
+@Entity
+public class Agent {
+
+	@Id @GeneratedValue
+	Long id;
+	String name;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	protected Agent() {}
+
+	public Agent(String name) {
+		this.name = name;
+	}
+}

--- a/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/domain/jpa/AgentRepository.java
+++ b/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/domain/jpa/AgentRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.core.domain.jpa;
+
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+/**
+ * @author Nick Weedon
+ */
+public interface AgentRepository extends PagingAndSortingRepository<Agent, Long> {
+	@Override
+	@PreAuthorize("hasAuthority('ROLE_ADMIN')")
+	public Agent findOne(Long pk);
+}

--- a/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/invoke/PagingAndSortingRepositoryInvokerIntegrationTests.java
+++ b/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/invoke/PagingAndSortingRepositoryInvokerIntegrationTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.core.invoke;
+
+
+import java.io.Serializable;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.repository.core.RepositoryInformation;
+import org.springframework.data.repository.support.Repositories;
+import org.springframework.data.rest.core.AbstractIntegrationTests;
+import org.springframework.data.rest.core.domain.jpa.Agent;
+import org.springframework.data.rest.core.domain.jpa.AgentRepository;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+
+/**
+ * Integration tests for {@link PagingAndSortingRepository}.
+ * 
+ * @author Nick Weedon
+ */
+public class PagingAndSortingRepositoryInvokerIntegrationTests extends AbstractIntegrationTests {
+
+	@Autowired Repositories repositories;
+	@Autowired ConversionService conversionService;
+	@Autowired AgentRepository repository;
+
+	RepositoryInformation information;
+	RepositoryInvoker invoker;
+
+	@SuppressWarnings("unchecked")
+	@Before
+	public void setUp() {
+
+		information = repositories.getRepositoryInformationFor(Agent.class);
+		Object repo = repository;
+		invoker = new PagingAndSortingRepositoryInvoker((PagingAndSortingRepository<Object, Serializable>)repo, information, conversionService);
+		if(repository.count() == 0) {
+			repository.save(new Agent("Smith"));
+			repository.save(new Agent("99"));
+			repository.save(new Agent("007"));
+			repository.save(new Agent("Powers"));
+		}
+	}
+
+	/**
+	 * @see DATAREST-216
+	 */
+	@Test(expected=AuthenticationCredentialsNotFoundException.class)
+	public void invokesFindOneWithStringIdCorrectly() {
+		invoker.invokeFindOne(new Long(2));
+	}
+
+}

--- a/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/mapping/ResourceMappingsIntegrationTests.java
+++ b/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/mapping/ResourceMappingsIntegrationTests.java
@@ -63,7 +63,7 @@ public class ResourceMappingsIntegrationTests {
 
 	@Test
 	public void detectsAllMappings() {
-		assertThat(mappings, is(Matchers.<ResourceMetadata> iterableWithSize(6)));
+		assertThat(mappings, is(Matchers.<ResourceMetadata> iterableWithSize(8)));
 	}
 
 	@Test

--- a/spring-data-rest-core/src/test/resources/testSecurity.xml
+++ b/spring-data-rest-core/src/test/resources/testSecurity.xml
@@ -1,0 +1,11 @@
+<beans:beans xmlns="http://www.springframework.org/schema/security"
+   xmlns:beans="http://www.springframework.org/schema/beans"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://www.springframework.org/schema/beans
+  http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+  http://www.springframework.org/schema/security
+  http://www.springframework.org/schema/security/spring-security-3.2.xsd">
+
+  <global-method-security pre-post-annotations="enabled"/> 
+  
+</beans:beans>


### PR DESCRIPTION
DATAREST-216 - Removed CrudRepositoryInvoker#invokeFindOne(Serializable id) method override as this will cause the findOne(Serializable id) method to be called instead of any existing, more specific methods. This in turn bypasses any AOP proxying of the more specific method. 

This possibly only occurs when JDK proxying is used and not CGLib.

Included is the fix implementation and unit test. The unit test effectively proves that there is an existing problem.

The unit test uses Spring method based security on the findOne method. 

I first attempted to reproduce this issue using AspectJ AOP, specifically using a @Before advice on the method. This seemed to work properly before this fix was applied. This is what makes me suspect that perhaps this relates only to JDK proxying but this is really only a guess.
