### PR TITLE
DATAREST-228: Add maven-enforcer-plugin to ensure building with Java 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 			<roles>
 				<role>Developer</role>
 			</roles>
-			<timezone>-5</timezone>
+			<timezone>-6</timezone>
 		</developer>
 	</developers>
 
@@ -124,6 +124,29 @@
 		</dependency>
 
 	</dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-rules</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>(1.7,1.8)</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 	<repositories>
 		<repository>


### PR DESCRIPTION
Added maven-enforcer-plugin so that builds fail fast if the wrong version of Java is being used.
