### PR TITLE
DATAREST-50: Add test case demonstrating this issue no longer exists

### DIFF
--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaWebTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaWebTests.java
@@ -298,6 +298,27 @@ public class JpaWebTests extends AbstractWebIntegrationTests {
 		assertSiblingNames(frodosSiblingsLink, "Bilbo", "Merry");
 	}
 
+	/**
+	 * @see DATAREST-50
+	 */
+	@Test
+	public void propertiesCanHaveNulls() throws Exception {
+
+		Link peopleLink = discoverUnique("people");
+		ObjectMapper mapper = new ObjectMapper();
+
+		Person frodo = new Person();
+		frodo.setFirstName("Frodo");
+		frodo.setLastName(null);
+
+		MockHttpServletResponse response = postAndGet(peopleLink, mapper.writeValueAsString(frodo),
+				MediaType.APPLICATION_JSON);
+		String responseBody = response.getContentAsString();
+
+		assertEquals(JsonPath.read(responseBody, "$.firstName"), "Frodo");
+		assertNull(JsonPath.read(responseBody, "$.lastName"));
+	}
+
 	private List<Link> preparePersonResources(Person primary, Person... persons) throws Exception {
 
 		Link peopleLink = discoverUnique("people");


### PR DESCRIPTION
Properties with null values properly get rendered in JSON outputs. This was fixed some time ago. Added test case to prove it.
