### PR TITLE
DATAREST-150: Add test case showing PUT now works correctly.

### DIFF
--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/AbstractWebIntegrationTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/AbstractWebIntegrationTests.java
@@ -164,7 +164,13 @@ public abstract class AbstractWebIntegrationTests {
 				andExpect(status().is(both(greaterThanOrEqualTo(200)).and(lessThan(300)))).//
 				andReturn().getResponse();
 
-		return StringUtils.hasText(response.getContentAsString()) ? response : request(link);
+		String content = response.getContentAsString();
+
+		if (StringUtils.hasText(content)) {
+			return response;
+		}
+
+		return request(link.expand().getHref());
 	}
 
 	protected MockHttpServletResponse patchAndGet(Link link, Object payload, MediaType mediaType) throws Exception {

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaWebTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaWebTests.java
@@ -207,7 +207,9 @@ public class JpaWebTests extends AbstractWebIntegrationTests {
 	@Test
 	public void createThenPatch() throws Exception {
 
-		MockHttpServletResponse bilbo = postAndGet(new Link("/people"),
+		Link peopleLink = discoverUnique("people");
+
+		MockHttpServletResponse bilbo = postAndGet(peopleLink,
 				"{ \"firstName\" : \"Bilbo\", \"lastName\" : \"Baggins\" }", MediaType.APPLICATION_JSON);
 
 		Link bilboLink = assertHasLinkWithRel("self", bilbo);
@@ -219,6 +221,34 @@ public class JpaWebTests extends AbstractWebIntegrationTests {
 
 		assertThat((String) JsonPath.read(frodo.getContentAsString(), "$.firstName"), equalTo("Frodo"));
 		assertThat((String) JsonPath.read(frodo.getContentAsString(), "$.lastName"), equalTo("Baggins"));
+	}
+
+	/**
+	 * @see DATAREST-150
+	 */
+	@Test
+	public void createThenPut() throws Exception {
+
+		Link peopleLink = discoverUnique("people");
+
+		MockHttpServletResponse bilbo = postAndGet(peopleLink,//
+				"{ \"firstName\" : \"Bilbo\", \"lastName\" : \"Baggins\" }",//
+				MediaType.APPLICATION_JSON);
+
+		Link bilboLink = assertHasLinkWithRel("self", bilbo);
+
+		assertThat((String) JsonPath.read(bilbo.getContentAsString(), "$.firstName"),
+				equalTo("Bilbo"));
+		assertThat((String) JsonPath.read(bilbo.getContentAsString(), "$.lastName"),
+				equalTo("Baggins"));
+
+		MockHttpServletResponse frodo = putAndGet(bilboLink,//
+				"{ \"firstName\" : \"Frodo\" }",//
+				MediaType.APPLICATION_JSON);
+
+		assertThat((String) JsonPath.read(frodo.getContentAsString(), "$.firstName"),
+				equalTo("Frodo"));
+		assertNull(JsonPath.read(frodo.getContentAsString(), "$.lastName"));
 	}
 
 	@Test


### PR DESCRIPTION
The JIRA issue asserts that PUT wasn't properly storing things. But now it does. A partial record causes all other fields to get nulled out. I added a test case to confirm this.
