### PR TITLE
Mismatch name between the argument name and the PathVariable

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/ControllerUtils.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/ControllerUtils.java
@@ -29,7 +29,7 @@ import org.springframework.http.ResponseEntity;
  */
 public class ControllerUtils {
 
-	public static final Iterable<Resource<?>> EMPTY_RESOURCE_LIST = Collections.emptyList();
+	public static final Iterable<Object> EMPTY_RESOURCE_LIST = Collections.emptyList();
 
 	/**
 	 * Wrap a resource as a {@link ResourceEntity} and attach given headers and status.

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositorySearchController.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositorySearchController.java
@@ -173,7 +173,7 @@ class RepositorySearchController extends AbstractRepositoryRestController {
 			links.add(resourceLink(resourceInformation, res));
 		}
 
-		return new Resource<Object>(EMPTY_RESOURCE_LIST, links);
+		return new Resources<Object>(EMPTY_RESOURCE_LIST, links);
 	}
 
 	/**


### PR DESCRIPTION
When the Accept Media Types contains application/*+json, Spring Data Rest use the method executeSearchCompact.
