### PR TITLE
Allow use of Jackson views

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/PersistentEntityJackson2Module.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/PersistentEntityJackson2Module.java
@@ -18,6 +18,7 @@ package org.springframework.data.rest.webmvc.json;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -246,10 +247,18 @@ public class PersistentEntityJackson2Module extends SimpleModule {
 					continue;
 				}
 
+				// Skip anything not in the active view (if we're using a view)
+				if (config.getActiveView() != null) {
+					if (writer.getViews() == null || !Arrays.asList(writer.getViews()).contains(config.getActiveView())) {
+						continue;
+					}
+				}
+
 				result.add(writer);
 			}
 
 			builder.setProperties(result);
+			builder.setFilteredProperties(result.toArray(new BeanPropertyWriter[result.size()]));
 
 			return builder;
 		}


### PR DESCRIPTION
Respect Jackson views on serialization.

Currently trying to use a view during serialization while this module is registered results in corruption of Jackson's internal state. Serialization fails since Jackson's list of filtered properties doesn't match its list of non-filtered properties.
