### PR TITLE
Resources processors to run for subclasses of Resources

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/ResourceProcessorHandlerMethodReturnValueHandler.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/ResourceProcessorHandlerMethodReturnValueHandler.java
@@ -421,7 +421,7 @@ public class ResourceProcessorHandlerMethodReturnValueHandler implements Handler
 		 */
 		private static boolean isValueTypeMatch(Resources<?> resources, TypeInformation<?> target) {
 
-			if (resources == null || !Resources.class.equals(resources.getClass())) {
+			if (resources == null || !Resources.class.isAssignableFrom(resources.getClass())) {
 				return false;
 			}
 
@@ -437,8 +437,8 @@ public class ResourceProcessorHandlerMethodReturnValueHandler implements Handler
 				return false;
 			}
 
-			TypeInformation<?> resourceTypeInformation = target.getSuperTypeInformation(Resources.class).getComponentType();
-			return ResourceProcessorWrapper.isValueTypeMatch((Resource<?>) element, resourceTypeInformation);
+            TypeInformation<?> resourceTypeInformation = target.getSuperTypeInformation(Resources.class).getComponentType();
+            return ResourceProcessorWrapper.isValueTypeMatch((Resource<?>) element, resourceTypeInformation);
 		}
 	}
 

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/ResourceProcessorHandlerMethodReturnValueHandlerUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/ResourceProcessorHandlerMethodReturnValueHandlerUnitTests.java
@@ -37,10 +37,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.core.MethodParameter;
-import org.springframework.hateoas.Link;
-import org.springframework.hateoas.Resource;
-import org.springframework.hateoas.ResourceProcessor;
-import org.springframework.hateoas.Resources;
+import org.springframework.data.domain.Page;
+import org.springframework.hateoas.*;
 import org.springframework.hateoas.mvc.HeaderLinksResponseEntity;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
@@ -61,7 +59,8 @@ public class ResourceProcessorHandlerMethodReturnValueHandlerUnitTests {
 
 	static final Resource<String> FOO = new Resource<String>("foo");
 	static final Resources<Resource<String>> FOOS = new Resources<Resource<String>>(Collections.singletonList(FOO));
-	static final StringResource FOO_RES = new StringResource("foo");
+    static final PagedResources<Resource<String>> PAGED_FOOS = new PagedResources<Resource<String>>(Collections.singletonList(FOO), new PagedResources.PageMetadata(1,0,1));
+    static final StringResource FOO_RES = new StringResource("foo");
 	static final HttpEntity<Resource<String>> FOO_ENTITY = new HttpEntity<Resource<String>>(FOO);
 	static final ResponseEntity<Resource<String>> FOO_RESP_ENTITY = new ResponseEntity<Resource<String>>(FOO,
 			HttpStatus.OK);
@@ -141,6 +140,30 @@ public class ResourceProcessorHandlerMethodReturnValueHandlerUnitTests {
 
 		invokeReturnValueHandler("resources", is(BARS), FOOS);
 	}
+
+    @Test
+    public void postProcessesStringPagedResources() throws Exception {
+        resourceProcessors.add(StringResourcesProcessor.INSTANCE);
+        resourceProcessors.add(LongResourceProcessor.INSTANCE);
+
+        invokeReturnValueHandler("pagedResources", is(BARS), PAGED_FOOS);
+    }
+
+    @Test
+    public void postProcessesStrings() throws Exception {
+        resourceProcessors.add(StringResourcesProcessor.INSTANCE);
+        resourceProcessors.add(LongResourceProcessor.INSTANCE);
+
+        invokeReturnValueHandler("strings", is(BARS), FOOS);
+    }
+
+    @Test
+    public void postProcessesStringsPage() throws Exception {
+        resourceProcessors.add(StringResourcesProcessor.INSTANCE);
+        resourceProcessors.add(LongResourceProcessor.INSTANCE);
+
+        invokeReturnValueHandler("pagedStrings", is(BARS), PAGED_FOOS);
+    }
 
 	@Test
 	public void postProcessesSpecializedStringResource() throws Exception {
@@ -278,6 +301,8 @@ public class ResourceProcessorHandlerMethodReturnValueHandlerUnitTests {
 
 		Resources<Resource<String>> resources();
 
+        PagedResources<Resource<String>> pagedResources();
+
 		Resource<String> resource();
 
 		Resource<Long> longResource();
@@ -285,6 +310,10 @@ public class ResourceProcessorHandlerMethodReturnValueHandlerUnitTests {
 		StringResource specializedResource();
 
 		Object object();
+
+        List<String> strings();
+
+        Page<String> pagedStrings();
 
 		HttpEntity<Resource<?>> resourceEntity();
 


### PR DESCRIPTION
When we changed the type of the return value in a repository from List<String> to Page<String> the Resources Processors didn't run, because the underlying resources type became PagedResources, which is a subclass of Resources.
This fix might be problematic in cases when somebody did hack around this deficiency, but I think it is always better to have generic Processors that could run on any subclass of Resources, not just specific ones. 
