### PR TITLE
DATAREST-332: Create @EnableRestRepositories to activate/configure SDR

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/EnableRestRepositories.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/EnableRestRepositories.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.webmvc.config;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Import;
+
+/**
+ * Annotation to enable Spring Data REST. Will pull in
+ * {@link org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguration}, which is
+ * {@link org.springframework.context.annotation.ImportAware} and can read the options from this annotation to
+ * configure Spring Data REST.
+ *
+ * @author Greg Turnquist
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(RepositoryRestMvcConfiguration.class)
+public @interface EnableRestRepositories {
+
+	String baseUri() default "";
+
+}

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/config/EnableRestRepositoriesTest.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/config/EnableRestRepositoriesTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.webmvc.config;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+
+import javax.sql.DataSource;
+
+import java.net.URI;
+
+import org.junit.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.Database;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+
+/**
+ * Test cases to confirm both {@link org.springframework.data.rest.webmvc.config.EnableRestRepositories} and
+ * {@link org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguration} work as options to configure
+ * Spring Data REST.
+ *
+ * @author Greg Turnquist
+ */
+public class EnableRestRepositoriesTest {
+
+	@Test
+	public void testAnnotationDrivenStartup() throws Exception {
+
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(AnnotationBasedTestConfiguration.class);
+		RepositoryRestConfiguration config = ctx.getBean(RepositoryRestConfiguration.class);
+		assertNotNull(config);
+		assertThat(config.getBaseUri().toString(), equalTo("/api"));
+
+		PersonRepository repository = ctx.getBean(PersonRepository.class);
+		assertNotNull(repository);
+	}
+
+	@Test
+	public void testImportDrivenDefaultStartup() throws Exception {
+
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(ImportBasedTestConfiguration.class);
+		RepositoryRestConfiguration config = ctx.getBean(RepositoryRestConfiguration.class);
+		assertNotNull(config);
+		assertThat(config.getBaseUri().toString(), equalTo(""));
+
+		PersonRepository repository = ctx.getBean(PersonRepository.class);
+		assertNotNull(repository);
+	}
+
+	@Test
+	public void testCustomDrivenStartup() throws Exception {
+
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(CustomConfiguration.class);
+		RepositoryRestConfiguration config = ctx.getBean(RepositoryRestConfiguration.class);
+		assertNotNull(config);
+		assertThat(config.getBaseUri().toString(), equalTo("/api"));
+
+		PersonRepository repository = ctx.getBean(PersonRepository.class);
+		assertNotNull(repository);
+	}
+
+	protected abstract static class AbstractConfiguration {
+
+		@Bean
+		public DataSource dataSource() {
+			EmbeddedDatabaseBuilder builder = new EmbeddedDatabaseBuilder();
+			return builder.setType(EmbeddedDatabaseType.HSQL).build();
+		}
+
+		@Bean
+		public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
+
+			HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+			vendorAdapter.setDatabase(Database.HSQL);
+			vendorAdapter.setGenerateDdl(true);
+
+			LocalContainerEntityManagerFactoryBean factory = new LocalContainerEntityManagerFactoryBean();
+			factory.setJpaVendorAdapter(vendorAdapter);
+			factory.setPackagesToScan(getClass().getPackage().getName());
+			factory.setPersistenceUnitName("spring-data-rest-webmvc");
+			factory.setDataSource(dataSource());
+			factory.afterPropertiesSet();
+
+			return factory;
+		}
+
+	}
+
+	@Configuration
+	@EnableJpaRepositories
+	@EnableRestRepositories(baseUri = "/api")
+	protected static class AnnotationBasedTestConfiguration extends AbstractConfiguration {
+	}
+
+	@Configuration
+	@EnableJpaRepositories
+	@Import(RepositoryRestMvcConfiguration.class)
+	protected static class ImportBasedTestConfiguration extends AbstractConfiguration {
+	}
+
+	@Configuration
+	@EnableJpaRepositories
+	@Import(CustomRepositoryRestMvcConfiguration.class)
+	protected static class CustomConfiguration extends AbstractConfiguration {
+	}
+
+	@Configuration
+	protected static class CustomRepositoryRestMvcConfiguration extends RepositoryRestMvcConfiguration {
+		@Override
+		public RepositoryRestConfiguration config() {
+			RepositoryRestConfiguration config = super.config();
+			config.setBaseUri(URI.create("/api"));
+			return config;
+
+		}
+	}
+
+}

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/config/Person.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/config/Person.java
@@ -1,0 +1,30 @@
+package org.springframework.data.rest.webmvc.config;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+class Person {
+	@Id
+	@GeneratedValue
+	long id;
+
+	private String name;
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/config/PersonRepository.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/config/PersonRepository.java
@@ -1,0 +1,9 @@
+package org.springframework.data.rest.webmvc.config;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource
+public interface PersonRepository extends CrudRepository<Person, Long> {
+
+}


### PR DESCRIPTION
- Provide alternative to @Import(RepositoryRestMvcConfiguration.class)
- Make it easier to alter baseUri (and other options in the future)
- Follow Spring convention of having @Enable annotation.
