### PR TITLE
Added an option to configure method argument resolvers registered by RepositoryRestMvcConfiguration

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
@@ -476,8 +476,10 @@ public class RepositoryRestMvcConfiguration extends HateoasAwareSpringDataWebCon
 
 		AnnotationAwareOrderComparator.sort(processors);
 
-		RepositoryRestHandlerAdapter handlerAdapter = new RepositoryRestHandlerAdapter(defaultMethodArgumentResolvers(),
-				processors);
+        List<HandlerMethodArgumentResolver> argumentResolvers = defaultMethodArgumentResolvers();
+        configureMethodArgumentResolvers(argumentResolvers);
+
+        RepositoryRestHandlerAdapter handlerAdapter = new RepositoryRestHandlerAdapter(argumentResolvers, processors);
 		handlerAdapter.setMessageConverters(messageConverters);
 
 		return handlerAdapter;
@@ -530,7 +532,10 @@ public class RepositoryRestMvcConfiguration extends HateoasAwareSpringDataWebCon
 	@Bean
 	public ExceptionHandlerExceptionResolver exceptionHandlerExceptionResolver() {
 		ExceptionHandlerExceptionResolver er = new ExceptionHandlerExceptionResolver();
-		er.setCustomArgumentResolvers(defaultMethodArgumentResolvers());
+
+        List<HandlerMethodArgumentResolver> argumentResolvers = defaultMethodArgumentResolvers();
+        configureMethodArgumentResolvers(argumentResolvers);
+        er.setCustomArgumentResolvers(argumentResolvers);
 
 		List<HttpMessageConverter<?>> messageConverters = defaultMessageConverters();
 		configureHttpMessageConverters(messageConverters);
@@ -721,6 +726,13 @@ public class RepositoryRestMvcConfiguration extends HateoasAwareSpringDataWebCon
 	 * @param messageConverters The converters to be used by the system.
 	 */
 	protected void configureHttpMessageConverters(List<HttpMessageConverter<?>> messageConverters) {}
+
+    /**
+     * Configure the available {@link HandlerMethodArgumentResolver}s.
+     *
+     * @param argumentResolvers The converters to be used by the system.
+     */
+    protected void configureMethodArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {}
 
 	/**
 	 * Configure the Jackson {@link ObjectMapper} directly.


### PR DESCRIPTION
I'm building a LightAdmin product on top of Spring Data REST and it would be really cool to make it a little bit more extendable in some aspects.
This pull request contains a small change to RepositoryRestMvcConfiguration and makes it possible to configure HandlerMethodArgumentResolver's registered.

PS: Currently, I need to do it like this: https://gist.github.com/max-dev/2b0ec3363e731801475f which is really awful.

Thanks)
