### PR TITLE
DATAREST-227: Break up AbstractWebIntegrationTest into simpler parts

### DIFF
--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/AbstractWebIntegrationTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/AbstractWebIntegrationTests.java
@@ -17,26 +17,20 @@ package org.springframework.data.rest.webmvc;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
-import static org.junit.Assume.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import net.minidev.json.JSONArray;
 
 import org.junit.Before;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguration;
 import org.springframework.hateoas.Link;
-import org.springframework.hateoas.LinkDiscoverer;
 import org.springframework.hateoas.LinkDiscoverers;
-import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -45,9 +39,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.ResultMatcher;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.LinkedMultiValueMap;
@@ -59,6 +51,10 @@ import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.JsonPath;
 
 /**
+ * A test harness for hypermedia unit/integration testing. Provides chained operations (like postAndGet) to create
+ * a new entity and then retrieve it with a single method call. It also provides often-used assertions (like
+ * assertJsonPathEquals).
+ *
  * @author Oliver Gierke
  * @author Greg Turnquist
  */
@@ -69,77 +65,18 @@ public abstract class AbstractWebIntegrationTests {
 
 	private static final String CONTENT_LINK_JSONPATH = "$._embedded.._links.%s.href[0]";
 
-	protected static MediaType DEFAULT_MEDIA_TYPE = org.springframework.hateoas.MediaTypes.HAL_JSON;
-
 	@Autowired WebApplicationContext context;
 	@Autowired LinkDiscoverers discoverers;
 
+	protected WebTestUtils webTestUtils;
 	protected MockMvc mvc;
 
 	@Before
 	public void setUp() {
 
 		mvc = MockMvcBuilders.webAppContextSetup(context).//
-				defaultRequest(get("/").accept(DEFAULT_MEDIA_TYPE)).build();
-	}
-
-	protected MockHttpServletResponse request(String href, MediaType contentType) throws Exception {
-		return mvc.perform(get(href).accept(contentType)). //
-				andExpect(status().isOk()). //
-				andExpect(content().contentType(contentType)). //
-				andReturn().getResponse();
-	}
-
-	protected MockHttpServletResponse request(Link link) throws Exception {
-		return request(link.expand().getHref());
-	}
-
-	protected MockHttpServletResponse request(Link link, MediaType mediaType) throws Exception {
-		return request(link.expand().getHref(), mediaType);
-	}
-
-	protected MockHttpServletResponse request(String href) throws Exception {
-		return request(href, DEFAULT_MEDIA_TYPE);
-	}
-
-	protected ResultActions follow(Link link) throws Exception {
-		return follow(link.expand().getHref());
-	}
-
-	protected ResultActions follow(String href) throws Exception {
-		return mvc.perform(get(href));
-	}
-
-	protected List<Link> discover(String rel) throws Exception {
-		return discover(new Link("/"), rel);
-	}
-
-	protected Link discoverUnique(String rel) throws Exception {
-
-		List<Link> discover = discover(rel);
-		assertThat(discover, hasSize(1));
-		return discover.get(0);
-	}
-
-	protected List<Link> discover(Link root, String rel) throws Exception {
-
-		MockHttpServletResponse response = mvc.perform(get(root.expand().getHref()).accept(DEFAULT_MEDIA_TYPE)).//
-				andExpect(status().isOk()).//
-				andExpect(hasLinkWithRel(rel)).//
-				andReturn().getResponse();
-
-		String s = response.getContentAsString();
-		return getDiscoverer(response).findLinksWithRel(rel, s);
-	}
-
-	protected Link discoverUnique(Link root, String rel) throws Exception {
-
-		MockHttpServletResponse response = mvc.perform(get(root.expand().getHref()).accept(DEFAULT_MEDIA_TYPE)).//
-				andExpect(status().isOk()).//
-				andExpect(hasLinkWithRel(rel)).//
-				andReturn().getResponse();
-
-		return assertHasLinkWithRel(rel, response);
+				defaultRequest(get("/").accept(WebTestUtils.DEFAULT_MEDIA_TYPE)).build();
+		webTestUtils = new WebTestUtils(mvc, discoverers);
 	}
 
 	protected MockHttpServletResponse postAndGet(Link link, Object payload, MediaType mediaType) throws Exception {
@@ -157,7 +94,7 @@ public abstract class AbstractWebIntegrationTests {
 			return response;
 		}
 
-		return request(response.getHeader("Location"));
+		return webTestUtils.request(response.getHeader("Location"));
 	}
 
 	protected MockHttpServletResponse putAndGet(Link link, Object payload, MediaType mediaType) throws Exception {
@@ -168,7 +105,7 @@ public abstract class AbstractWebIntegrationTests {
 				andExpect(status().is(both(greaterThanOrEqualTo(200)).and(lessThan(300)))).//
 				andReturn().getResponse();
 
-		return StringUtils.hasText(response.getContentAsString()) ? response : request(link);
+		return StringUtils.hasText(response.getContentAsString()) ? response : webTestUtils.request(link);
 	}
 
 	protected MockHttpServletResponse patchAndGet(Link link, Object payload, MediaType mediaType) throws Exception {
@@ -180,7 +117,7 @@ public abstract class AbstractWebIntegrationTests {
 				andExpect(status().isNoContent()).//
 				andReturn().getResponse();
 
-		return StringUtils.hasText(response.getContentAsString()) ? response : request(href);
+		return StringUtils.hasText(response.getContentAsString()) ? response : webTestUtils.request(href);
 	}
 
 	protected void deleteAndVerify(Link link) throws Exception {
@@ -194,17 +131,6 @@ public abstract class AbstractWebIntegrationTests {
 		// Check that the resource is unavailable after a DELETE
 		mvc.perform(get(href)).//
 				andExpect(status().isNotFound());
-	}
-
-	protected Link assertHasLinkWithRel(String rel, MockHttpServletResponse response) throws Exception {
-
-		String content = response.getContentAsString();
-		Link link = getDiscoverer(response).findLinkWithRel(rel, content);
-
-		assertThat("Expected to find link with rel " + rel + " but found none in " + content + "!", link,
-				is(notNullValue()));
-
-		return link;
 	}
 
 	protected Link assertHasContentLinkWithRel(String rel, MockHttpServletResponse response) throws Exception {
@@ -241,20 +167,9 @@ public abstract class AbstractWebIntegrationTests {
 	protected void assertDoesNotHaveLinkWithRel(String rel, MockHttpServletResponse response) throws Exception {
 
 		String content = response.getContentAsString();
-		Link link = getDiscoverer(response).findLinkWithRel(rel, content);
+		Link link = webTestUtils.getDiscoverer(response).findLinkWithRel(rel, content);
 
 		assertThat("Expected not to find link with rel " + rel + " but found " + link + "!", link, is(nullValue()));
-	}
-
-	private LinkDiscoverer getDiscoverer(MockHttpServletResponse response) {
-
-		String contentType = response.getContentType();
-		LinkDiscoverer linkDiscovererFor = discoverers.getLinkDiscovererFor(contentType);
-
-		assertThat("Did not find a LinkDiscoverer for returned media type " + contentType + "!", linkDiscovererFor,
-				is(notNullValue()));
-
-		return linkDiscovererFor;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -296,22 +211,6 @@ public abstract class AbstractWebIntegrationTests {
 		return jsonQueryResults;
 	}
 
-	protected ResultMatcher hasLinkWithRel(final String rel) {
-
-		return new ResultMatcher() {
-
-			@Override
-			public void match(MvcResult result) throws Exception {
-
-				MockHttpServletResponse response = result.getResponse();
-				String s = response.getContentAsString();
-
-				assertThat("Expected to find link with rel " + rel + " but found none in " + s, //
-						getDiscoverer(response).findLinkWithRel(rel, s), notNullValue());
-			}
-		};
-	}
-
 	protected ResultMatcher doesNotHaveLinkWithRel(final String rel) {
 
 		return new ResultMatcher() {
@@ -323,159 +222,9 @@ public abstract class AbstractWebIntegrationTests {
 				String s = response.getContentAsString();
 
 				assertThat("Expected not to find link with rel " + rel + " but found one in " + s, //
-						getDiscoverer(response).findLinkWithRel(rel, s), nullValue());
+						webTestUtils.getDiscoverer(response).findLinkWithRel(rel, s), nullValue());
 			}
 		};
-	}
-
-	// Root test cases
-
-	@Test
-	public void exposesRootResource() throws Exception {
-
-		ResultActions actions = mvc.perform(get("/").accept(DEFAULT_MEDIA_TYPE)).andExpect(status().isOk());
-
-		for (String rel : expectedRootLinkRels()) {
-			actions.andExpect(hasLinkWithRel(rel));
-		}
-	}
-
-	/**
-	 * @see DATAREST-113
-	 */
-	@Test
-	public void exposesSchemasForResourcesExposed() throws Exception {
-
-		MockHttpServletResponse response = request("/");
-
-		for (String rel : expectedRootLinkRels()) {
-
-			Link link = assertHasLinkWithRel(rel, response);
-
-			// Resource
-			request(link);
-
-			// Schema - TODO:Improve by using hypermedia
-			mvc.perform(get(link.expand().getHref() + "/schema").//
-					accept(MediaType.parseMediaType("application/schema+json"))).//
-					andExpect(status().isOk());
-		}
-	}
-
-	/**
-	 * @see DATAREST-203
-	 */
-	@Test
-	public void servesHalWhenRequested() throws Exception {
-
-		mvc.perform(get("/")). //
-				andExpect(content().contentType(MediaTypes.HAL_JSON)). //
-				andExpect(jsonPath("$._links", notNullValue()));
-	}
-
-	/**
-	 * @see DATAREST-203
-	 */
-	@Test
-	public void servesHalWhenJsonIsRequested() throws Exception {
-
-		mvc.perform(get("/").accept(MediaType.APPLICATION_JSON)). //
-				andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON)). //
-				andExpect(jsonPath("$._links", notNullValue()));
-	}
-
-	/**
-	 * @see DATAREST-203
-	 */
-	@Test
-	public void exposesSearchesForRootResources() throws Exception {
-
-		MockHttpServletResponse response = request("/");
-
-		for (String rel : expectedRootLinkRels()) {
-
-			Link link = assertHasLinkWithRel(rel, response);
-			String rootResourceRepresentation = request(link).getContentAsString();
-			Link searchLink = getDiscoverer(response).findLinkWithRel("search", rootResourceRepresentation);
-
-			if (searchLink != null) {
-				request(searchLink);
-			}
-		}
-	}
-
-	@Test
-	public void nic() throws Exception {
-
-		Map<String, String> payloads = getPayloadToPost();
-		assumeFalse(payloads.isEmpty());
-
-		MockHttpServletResponse response = request("/");
-
-		for (String rel : expectedRootLinkRels()) {
-
-			String payload = payloads.get(rel);
-
-			if (payload != null) {
-
-				Link link = assertHasLinkWithRel(rel, response);
-				String target = link.expand().getHref();
-
-				MockHttpServletRequestBuilder request = post(target).//
-						content(payload).//
-						contentType(MediaType.APPLICATION_JSON);
-
-				mvc.perform(request). //
-						andExpect(status().isCreated());
-			}
-		}
-	}
-
-	/**
-	 * @see DATAREST-198
-	 */
-	@Test
-	public void accessLinkedResources() throws Exception {
-
-		MockHttpServletResponse rootResource = request("/");
-
-		for (Entry<String, List<String>> linked : getRootAndLinkedResources().entrySet()) {
-
-			Link resourceLink = assertHasLinkWithRel(linked.getKey(), rootResource);
-			MockHttpServletResponse resource = request(resourceLink);
-
-			for (String linkedRel : linked.getValue()) {
-
-				// Find URIs pointing to linked resources
-				String jsonPath = String.format("$..%s._links.%s.href", linked.getKey(), linkedRel);
-				String representation = resource.getContentAsString();
-				JSONArray uris = JsonPath.read(representation, jsonPath);
-
-				for (Object href : uris) {
-
-					follow(href.toString()). //
-							andExpect(status().isOk());
-				}
-			}
-		}
-	}
-
-	/**
-	 * @see DATAREST-230
-	 */
-	@Test
-	public void exposesDescriptionAsAlpsDocuments() throws Exception {
-
-		MediaType ALPS_MEDIA_TYPE = MediaType.valueOf("application/alps+json");
-
-		MockHttpServletResponse response = request("/");
-		Link profileLink = assertHasLinkWithRel("profile", response);
-
-		mvc.perform(//
-				get(profileLink.expand().getHref()).//
-						accept(ALPS_MEDIA_TYPE)).//
-				andExpect(status().isOk()).//
-				andExpect(content().contentType(ALPS_MEDIA_TYPE));
 	}
 
 	protected abstract Iterable<String> expectedRootLinkRels();

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/CommonWebTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/CommonWebTests.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.rest.webmvc;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assume.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+import java.util.Map;
+
+import net.minidev.json.JSONArray;
+
+import org.junit.Test;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import com.jayway.jsonpath.JsonPath;
+
+/**
+ * This class contains a common test suite used to verify multiple data stores with the same domain space.
+ * When verifying support of a new data store, it's good to start with extending this suite of tests. However,
+ * if the data store doesn't map well onto this, then a good alternative would be write a new test suite
+ * using {@link org.springframework.data.rest.webmvc.AbstractWebIntegrationTests AbstractWebIntegrationTests} as
+ * the test harness.
+ *
+ * @author Oliver Gierke
+ * @author Greg Turnquist
+ */
+public abstract class CommonWebTests extends AbstractWebIntegrationTests {
+
+	// Root test cases
+
+	@Test
+	public void exposesRootResource() throws Exception {
+
+		ResultActions actions = mvc.perform(get("/").accept(WebTestUtils.DEFAULT_MEDIA_TYPE)).andExpect(status().isOk());
+
+		for (String rel : expectedRootLinkRels()) {
+			actions.andExpect(webTestUtils.hasLinkWithRel(rel));
+		}
+	}
+
+	/**
+	 * @see DATAREST-113
+	 */
+	@Test
+	public void exposesSchemasForResourcesExposed() throws Exception {
+
+		MockHttpServletResponse response = webTestUtils.request("/");
+
+		for (String rel : expectedRootLinkRels()) {
+
+			Link link = webTestUtils.assertHasLinkWithRel(rel, response);
+
+			// Resource
+			webTestUtils.request(link);
+
+			// Schema - TODO:Improve by using hypermedia
+			mvc.perform(get(link.expand().getHref() + "/schema").//
+					accept(MediaType.parseMediaType("application/schema+json"))).//
+					andExpect(status().isOk());
+		}
+	}
+
+	/**
+	 * @see DATAREST-203
+	 */
+	@Test
+	public void servesHalWhenRequested() throws Exception {
+
+		mvc.perform(get("/")). //
+				andExpect(content().contentType(MediaTypes.HAL_JSON)). //
+				andExpect(jsonPath("$._links", notNullValue()));
+	}
+
+	/**
+	 * @see DATAREST-203
+	 */
+	@Test
+	public void servesHalWhenJsonIsRequested() throws Exception {
+
+		mvc.perform(get("/").accept(MediaType.APPLICATION_JSON)). //
+				andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON)). //
+				andExpect(jsonPath("$._links", notNullValue()));
+	}
+
+	/**
+	 * @see DATAREST-203
+	 */
+	@Test
+	public void exposesSearchesForRootResources() throws Exception {
+
+		MockHttpServletResponse response = webTestUtils.request("/");
+
+		for (String rel : expectedRootLinkRels()) {
+
+			Link link = webTestUtils.assertHasLinkWithRel(rel, response);
+			String rootResourceRepresentation = webTestUtils.request(link).getContentAsString();
+			Link searchLink = webTestUtils.getDiscoverer(response).findLinkWithRel("search", rootResourceRepresentation);
+
+			if (searchLink != null) {
+				webTestUtils.request(searchLink);
+			}
+		}
+	}
+
+	@Test
+	public void nic() throws Exception {
+
+		Map<String, String> payloads = getPayloadToPost();
+		assumeFalse(payloads.isEmpty());
+
+		MockHttpServletResponse response = webTestUtils.request("/");
+
+		for (String rel : expectedRootLinkRels()) {
+
+			String payload = payloads.get(rel);
+
+			if (payload != null) {
+
+				Link link = webTestUtils.assertHasLinkWithRel(rel, response);
+				String target = link.expand().getHref();
+
+				MockHttpServletRequestBuilder request = post(target).//
+						content(payload).//
+						contentType(MediaType.APPLICATION_JSON);
+
+				mvc.perform(request). //
+						andExpect(status().isCreated());
+			}
+		}
+	}
+
+	/**
+	 * @see DATAREST-198
+	 */
+	@Test
+	public void accessLinkedResources() throws Exception {
+
+		MockHttpServletResponse rootResource = webTestUtils.request("/");
+
+		for (Map.Entry<String, List<String>> linked : getRootAndLinkedResources().entrySet()) {
+
+			Link resourceLink = webTestUtils.assertHasLinkWithRel(linked.getKey(), rootResource);
+			MockHttpServletResponse resource = webTestUtils.request(resourceLink);
+
+			for (String linkedRel : linked.getValue()) {
+
+				// Find URIs pointing to linked resources
+				String jsonPath = String.format("$..%s._links.%s.href", linked.getKey(), linkedRel);
+				String representation = resource.getContentAsString();
+				JSONArray uris = JsonPath.read(representation, jsonPath);
+
+				for (Object href : uris) {
+
+					webTestUtils.follow(href.toString()). //
+							andExpect(status().isOk());
+				}
+			}
+		}
+	}
+
+	/**
+	 * @see DATAREST-230
+	 */
+	@Test
+	public void exposesDescriptionAsAlpsDocuments() throws Exception {
+
+		MediaType ALPS_MEDIA_TYPE = MediaType.valueOf("application/alps+json");
+
+		MockHttpServletResponse response = webTestUtils.request("/");
+		Link profileLink = webTestUtils.assertHasLinkWithRel("profile", response);
+
+		mvc.perform(//
+				get(profileLink.expand().getHref()).//
+						accept(ALPS_MEDIA_TYPE)).//
+				andExpect(status().isOk()).//
+				andExpect(content().contentType(ALPS_MEDIA_TYPE));
+	}
+
+}

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/WebTestUtils.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/WebTestUtils.java
@@ -17,11 +17,24 @@ package org.springframework.data.rest.webmvc;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.List;
+
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.LinkDiscoverer;
+import org.springframework.hateoas.LinkDiscoverers;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
@@ -29,8 +42,19 @@ import org.springframework.web.context.request.ServletRequestAttributes;
  * Helper methods for web integration testing.
  * 
  * @author Oliver Gierke
+ * @author Greg Turnquist
  */
 public class WebTestUtils {
+
+	public static MediaType DEFAULT_MEDIA_TYPE = org.springframework.hateoas.MediaTypes.HAL_JSON;
+
+	private final MockMvc mvc;
+	private final LinkDiscoverers discoverers;
+
+	public WebTestUtils(MockMvc mvc, LinkDiscoverers discoverers) {
+		this.mvc = mvc;
+		this.discoverers = discoverers;
+	}
 
 	/**
 	 * Initializes web tests. Will register a {@link MockHttpServletRequest} for the current thread.
@@ -49,4 +73,200 @@ public class WebTestUtils {
 		assertThat(headers.getAllow(), hasSize(methods.length));
 		assertThat(headers.getAllow(), hasItems(methods));
 	}
+
+	/**
+	 * Perform GET [href] with an explicit Accept media type using MockMvc. Verify the requests succeeded
+	 * and also came back as the Accept type.
+	 *
+	 * @param href
+	 * @param contentType
+	 * @return a mocked servlet response with results from GET [href]
+	 * @throws Exception
+	 */
+	public MockHttpServletResponse request(String href, MediaType contentType) throws Exception {
+		return mvc.perform(get(href).accept(contentType)). //
+				andExpect(status().isOk()). //
+				andExpect(content().contentType(contentType)). //
+				andReturn().getResponse();
+	}
+
+	/**
+	 * Convenience wrapper that first expands the link using URI substitution before requesting with the
+	 * default media type.
+	 *
+	 * @param link
+	 * @return
+	 * @throws Exception
+	 */
+	public MockHttpServletResponse request(Link link) throws Exception {
+		return request(link.expand().getHref());
+	}
+
+	/**
+	 * Convenience wrapper that first expands the link using URI substitution and then GET [href] using
+	 * an explicit media type
+	 *
+	 * @param link
+	 * @param mediaType
+	 * @return
+	 * @throws Exception
+	 */
+	public MockHttpServletResponse request(Link link, MediaType mediaType) throws Exception {
+		return request(link.expand().getHref(), mediaType);
+	}
+
+	/**
+	 * Convenience wrapper to GET [href] using the default media type.
+	 *
+	 * @param href
+	 * @return
+	 * @throws Exception
+	 */
+	public MockHttpServletResponse request(String href) throws Exception {
+		return request(href, DEFAULT_MEDIA_TYPE);
+	}
+
+	/**
+	 * For a given link, expand the href using URI substitution and then do a simple GET.
+	 *
+	 * @param link
+	 * @return
+	 * @throws Exception
+	 */
+	public ResultActions follow(Link link) throws Exception {
+		return follow(link.expand().getHref());
+	}
+
+	/**
+	 * Follow URL supplied as a string. NOTE: Assumes no URI templates.
+	 *
+	 * @param href
+	 * @return
+	 * @throws Exception
+	 */
+	public ResultActions follow(String href) throws Exception {
+		return mvc.perform(get(href));
+	}
+
+	/**
+	 * Discover list of URIs associated with a rel, starting at the root node ("/")
+	 *
+	 * @param rel
+	 * @return
+	 * @throws Exception
+	 */
+	public List<Link> discover(String rel) throws Exception {
+		return discover(new Link("/"), rel);
+	}
+
+	/**
+	 * Discover single URI associated with a rel, starting at the root node ("/")
+	 * @param rel
+	 * @return
+	 * @throws Exception
+	 */
+	public Link discoverUnique(String rel) throws Exception {
+
+		List<Link> discover = discover(rel);
+		assertThat(discover, hasSize(1));
+		return discover.get(0);
+	}
+
+	/**
+	 * Given a URI (root), discover the URIs for a given rel.
+	 *
+	 * @param root - URI to start from
+	 * @param rel - name of the relationship to seek links
+	 * @return list of {@link org.springframework.hateoas.Link Link} objects associated with the rel
+	 * @throws Exception
+	 */
+	public List<Link> discover(Link root, String rel) throws Exception {
+
+		MockHttpServletResponse response = mvc.perform(get(root.expand().getHref()).accept(DEFAULT_MEDIA_TYPE)).//
+				andExpect(status().isOk()).//
+				andExpect(hasLinkWithRel(rel)).//
+				andReturn().getResponse();
+
+		String s = response.getContentAsString();
+		return getDiscoverer(response).findLinksWithRel(rel, s);
+	}
+
+	/**
+	 * Given a URI (root), discover the unique URI for a given rel. NOTE: Assumes there is only one URI
+	 *
+	 * @param root
+	 * @param rel
+	 * @return {@link org.springframework.hateoas.Link Link} tied to a given rel
+	 * @throws Exception
+	 */
+	public Link discoverUnique(Link root, String rel) throws Exception {
+
+		MockHttpServletResponse response = mvc.perform(get(root.expand().getHref()).accept(DEFAULT_MEDIA_TYPE)).//
+				andExpect(status().isOk()).//
+				andExpect(hasLinkWithRel(rel)).//
+				andReturn().getResponse();
+
+		return assertHasLinkWithRel(rel, response);
+	}
+
+	/**
+	 * For a given servlet response, verify that the provided rel exists in its hypermedia. If so,
+	 * return the URI link.
+	 *
+	 * @param rel
+	 * @param response
+	 * @return {@link org.springframework.hateoas.Link} of the rel found in the response
+	 * @throws Exception
+	 */
+	public Link assertHasLinkWithRel(String rel, MockHttpServletResponse response) throws Exception {
+
+		String content = response.getContentAsString();
+		Link link = getDiscoverer(response).findLinkWithRel(rel, content);
+
+		assertThat("Expected to find link with rel " + rel + " but found none in " + content + "!", link,
+				is(notNullValue()));
+
+		return link;
+	}
+
+	/**
+	 * MockMvc matcher used to verify existence of rel with URI link
+	 *
+	 * @param rel
+	 * @return
+	 */
+	public ResultMatcher hasLinkWithRel(final String rel) {
+
+		return new ResultMatcher() {
+
+			@Override
+			public void match(MvcResult result) throws Exception {
+
+				MockHttpServletResponse response = result.getResponse();
+				String s = response.getContentAsString();
+
+				assertThat("Expected to find link with rel " + rel + " but found none in " + s, //
+						getDiscoverer(response).findLinkWithRel(rel, s), notNullValue());
+			}
+		};
+	}
+
+	/**
+	 * Using the servlet response's content type, find the corresponding link discoverer.
+	 *
+	 * @param response
+	 * @return {@link org.springframework.hateoas.LinkDiscoverer}
+	 */
+	public LinkDiscoverer getDiscoverer(MockHttpServletResponse response) {
+
+		String contentType = response.getContentType();
+		LinkDiscoverer linkDiscovererFor = discoverers.getLinkDiscovererFor(contentType);
+
+		assertThat("Did not find a LinkDiscoverer for returned media type " + contentType + "!", linkDiscovererFor,
+				is(notNullValue()));
+
+		return linkDiscovererFor;
+	}
+
+
 }

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/gemfire/GemfireWebTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/gemfire/GemfireWebTests.java
@@ -17,14 +17,14 @@ package org.springframework.data.rest.webmvc.gemfire;
 
 import java.util.Arrays;
 
-import org.springframework.data.rest.webmvc.AbstractWebIntegrationTests;
+import org.springframework.data.rest.webmvc.CommonWebTests;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
  * @author Oliver Gierke
  */
 @ContextConfiguration(classes = GemfireRepositoryConfig.class)
-public class GemfireWebTests extends AbstractWebIntegrationTests {
+public class GemfireWebTests extends CommonWebTests {
 
 	/* 
 	 * (non-Javadoc)

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/mongodb/MongoWebTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/mongodb/MongoWebTests.java
@@ -25,7 +25,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.rest.webmvc.AbstractWebIntegrationTests;
+import org.springframework.data.rest.webmvc.CommonWebTests;
 import org.springframework.data.rest.webmvc.RestMediaTypes;
 import org.springframework.hateoas.Link;
 import org.springframework.http.MediaType;
@@ -38,9 +38,10 @@ import com.jayway.jsonpath.JsonPath;
  * Integration tests for MongoDB repositories.
  * 
  * @author Oliver Gierke
+ * @author Greg Turnquist
  */
 @ContextConfiguration(classes = MongoDbRepositoryConfig.class)
-public class MongoWebTests extends AbstractWebIntegrationTests {
+public class MongoWebTests extends CommonWebTests {
 
 	@Autowired ProfileRepository repository;
 	@Autowired UserRepository userRepository;
@@ -88,17 +89,17 @@ public class MongoWebTests extends AbstractWebIntegrationTests {
 	@Test
 	public void foo() throws Exception {
 
-		Link profileLink = discoverUnique("profiles");
-		follow(profileLink).//
+		Link profileLink = webTestUtils.discoverUnique("profiles");
+		webTestUtils.follow(profileLink).//
 				andExpect(jsonPath("$._embedded.profiles").value(hasSize(2)));
 	}
 
 	@Test
 	public void rendersEmbeddedDocuments() throws Exception {
 
-		Link usersLink = discoverUnique("users");
-		Link userLink = assertHasContentLinkWithRel("self", request(usersLink));
-		follow(userLink).//
+		Link usersLink = webTestUtils.discoverUnique("users");
+		Link userLink = assertHasContentLinkWithRel("self", webTestUtils.request(usersLink));
+		webTestUtils.follow(userLink).//
 				andExpect(jsonPath("$.address.zipCode").value(is(notNullValue())));
 	}
 
@@ -108,22 +109,22 @@ public class MongoWebTests extends AbstractWebIntegrationTests {
 	@Test
 	public void executeQueryMethodWithPrimitiveReturnType() throws Exception {
 
-		Link profiles = discoverUnique("profiles");
-		Link profileSearches = discoverUnique(profiles, "search");
-		Link countByTypeLink = discoverUnique(profileSearches, "countByType");
+		Link profiles = webTestUtils.discoverUnique("profiles");
+		Link profileSearches = webTestUtils.discoverUnique(profiles, "search");
+		Link countByTypeLink = webTestUtils.discoverUnique(profileSearches, "countByType");
 
 		assertThat(countByTypeLink.isTemplated(), is(true));
 		assertThat(countByTypeLink.getVariableNames(), hasItem("type"));
 
-		MockHttpServletResponse response = request(countByTypeLink.expand("Twitter"));
+		MockHttpServletResponse response = webTestUtils.request(countByTypeLink.expand("Twitter"));
 		assertThat(response.getContentAsString(), is("1"));
 	}
 
 	@Test
 	public void testname() throws Exception {
 
-		Link usersLink = discoverUnique("users");
-		Link userLink = assertHasContentLinkWithRel("self", request(usersLink));
+		Link usersLink = webTestUtils.discoverUnique("users");
+		Link userLink = assertHasContentLinkWithRel("self", webTestUtils.request(usersLink));
 
 		MockHttpServletResponse response = patchAndGet(userLink,
 				"{\"lastname\" : null, \"address\" : { \"zipCode\" : \"ZIP\"}}", MediaType.APPLICATION_JSON);
@@ -135,8 +136,8 @@ public class MongoWebTests extends AbstractWebIntegrationTests {
 	@Test
 	public void testname2() throws Exception {
 
-		Link usersLink = discoverUnique("users");
-		Link userLink = assertHasContentLinkWithRel("self", request(usersLink));
+		Link usersLink = webTestUtils.discoverUnique("users");
+		Link userLink = assertHasContentLinkWithRel("self", webTestUtils.request(usersLink));
 
 		MockHttpServletResponse response = patchAndGet(userLink,
 				"[{ \"op\": \"replace\", \"path\": \"/address/zipCode\", \"value\": \"ZIP\" },"

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/neo4j/Neo4jWebTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/neo4j/Neo4jWebTests.java
@@ -30,7 +30,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.neo4j.config.EnableNeo4jRepositories;
 import org.springframework.data.neo4j.config.Neo4jConfiguration;
-import org.springframework.data.rest.webmvc.AbstractWebIntegrationTests;
+import org.springframework.data.rest.webmvc.CommonWebTests;
 import org.springframework.hateoas.Link;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
@@ -42,7 +42,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
  */
 @ContextConfiguration
 @Ignore
-public class Neo4jWebTests extends AbstractWebIntegrationTests {
+public class Neo4jWebTests extends CommonWebTests {
 
 	@Configuration
 	@ComponentScan
@@ -86,13 +86,13 @@ public class Neo4jWebTests extends AbstractWebIntegrationTests {
 	public void deletesCustomer() throws Exception {
 
 		// Lookup customer
-		Link customers = discoverUnique("customers");
-		Link customerLink = assertHasContentLinkWithRel("self", request(customers));
+		Link customers = webTestUtils.discoverUnique("customers");
+		Link customerLink = assertHasContentLinkWithRel("self", webTestUtils.request(customers));
 
 		// Delete customer
 		mvc.perform(delete(customerLink.getHref()));
 
 		// Assert no customers anymore
-		assertDoesNotHaveContentLinkWithRel("self", request(customers));
+		assertDoesNotHaveContentLinkWithRel("self", webTestUtils.request(customers));
 	}
 }


### PR DESCRIPTION
Decouple the test machinery of this class from the barrage of common test cases used against the various data stores. This way, other test suites that use the same integration approach don't have to be a part of this class hierarchy. 

Also move utilities and assertion methods into separate utility classes to slim down the class hierarchy.
