### PR TITLE
Exception handling patch

### DIFF
--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/event/AnnotatedHandlerBeanPostProcessor.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/event/AnnotatedHandlerBeanPostProcessor.java
@@ -30,6 +30,7 @@ import org.springframework.util.ReflectionUtils;
 
 /**
  * @author Jon Brisbin
+ * @author Saulo Medeiros de Araujo
  */
 public class AnnotatedHandlerBeanPostProcessor implements ApplicationListener<RepositoryEvent>, BeanPostProcessor {
 


### PR DESCRIPTION
Spring Data REST is capturing any exceptions thrown by event handler methods and rethrowing them as IllegalStateException. By doing this, Spring Data REST makes it very hard to adopt any exception handling mechanism offered by Spring MVC (controller advices, for example) because we cannot pinpoint which exception we would like to handle in each exception handler of the controller advice (the only exception that we can handle is IllegalStateException). This patch corrects this behaviour. If a event handler throws a unchecked exception, than it makes sure that this very exception is thrown. Otherwise (if it is a checked exception), it resorts to the old behavior, encapsulating the checked exception in a IllegalStateException. Without this patch, the controller advice shown below does not work.

``` java
@ControllerAdvice
public class ExceptionHandlingControllerAdvice {
    @ExceptionHandler(UnauthorizedException.class)
    public ResponseEntity handleUnauthorizedException(UnauthorizedException exception) {
        String stackTrace = ExceptionUtils.getStackTrace(exception);
        return new ResponseEntity(stackTrace, HttpStatus.FORBIDDEN); 
    }
}
```

By applying this patch, I believe Spring Data REST better fits the Spring MVC world.
