### PR TITLE
Projection patch

### DIFF
--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/projection/ProjectingMethodInterceptor.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/projection/ProjectingMethodInterceptor.java
@@ -30,6 +30,7 @@ import org.springframework.util.ClassUtils;
  * projecting proxy in case the returned value is not of the return type of the invoked method.
  * 
  * @author Oliver Gierke
+ * @author Saulo Medeiros de Araujo 
  */
 class ProjectingMethodInterceptor implements MethodInterceptor {
 

--- a/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/projection/ProjectingMethodInterceptorUnitTests.java
+++ b/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/projection/ProjectingMethodInterceptorUnitTests.java
@@ -15,10 +15,23 @@
  */
 package org.springframework.data.rest.core.projection;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
@@ -31,6 +44,7 @@ import org.mockito.runners.MockitoJUnitRunner;
  * Unit tests for {@link ProjectingMethodInterceptor}.
  * 
  * @author Oliver Gierke
+ * @author Saulo Medeiros de Araujo 
  */
 @RunWith(MockitoJUnitRunner.class)
 public class ProjectingMethodInterceptorUnitTests {
@@ -95,6 +109,83 @@ public class ProjectingMethodInterceptorUnitTests {
 		verify(factory, times(0)).createProjection(anyObject(), (Class<?>) anyObject());
 	}
 
+	/**
+	 * @see DATAREST-394
+	 */		
+	@Test
+	public void appliesProjectionToNonEmptyCollections() throws Throwable {
+		
+		MethodInterceptor methodInterceptor = new ProjectingMethodInterceptor(new ProxyProjectionFactory(null), interceptor);
+
+		Helper helper = mock(Helper.class); 
+
+		Collection<Helper> helpers = new ArrayList<Helper>();
+		helpers.add(helper);
+
+		when(invocation.getMethod()).thenReturn(Helper.class.getMethod("getHelperCollection"));
+		when(interceptor.invoke(invocation)).thenReturn(helpers);
+
+		Object result = methodInterceptor.invoke(invocation);
+		assertThat(result, is(instanceOf(Collection.class)));
+		
+		Collection<?> projections = (Collection<?>) result;
+		assertThat(projections, is(not(empty())));
+		
+		Object projection = projections.iterator().next();
+		assertThat(projection, is(instanceOf(HelperProjection.class)));
+	}
+
+	/**
+	 * @see DATAREST-394
+	 */			
+	@Test
+	public void appliesProjectionToNonEmptyLists() throws Throwable {
+		
+		MethodInterceptor methodInterceptor = new ProjectingMethodInterceptor(new ProxyProjectionFactory(null), interceptor);
+
+		Helper helper = mock(Helper.class); 
+
+		List<Helper> helpers = new ArrayList<Helper>();
+		helpers.add(helper);
+
+		when(invocation.getMethod()).thenReturn(Helper.class.getMethod("getHelperList"));
+		when(interceptor.invoke(invocation)).thenReturn(helpers);
+
+		Object result = methodInterceptor.invoke(invocation);
+		assertThat(result, is(instanceOf(List.class)));
+		
+		List<?> projections = (List<?>) result;
+		assertThat(projections, is(not(empty())));
+		
+		Object projection = projections.get(0);
+		assertThat(projection, is(instanceOf(HelperProjection.class)));		
+	}
+
+	/**
+	 * @see DATAREST-394
+	 */			
+	@Test
+	public void doesNotApplyProjectionSets() throws Throwable {
+		MethodInterceptor methodInterceptor = new ProjectingMethodInterceptor(new ProxyProjectionFactory(null), interceptor);
+
+		Helper helper = mock(Helper.class); 
+
+		Set<Helper> helpers = new HashSet<Helper>();
+		helpers.add(helper);
+
+		when(invocation.getMethod()).thenReturn(Helper.class.getMethod("getHelperSet"));
+		when(interceptor.invoke(invocation)).thenReturn(helpers);
+
+		Object result = methodInterceptor.invoke(invocation);
+		assertThat(result, is(instanceOf(Set.class)));
+		
+		Set<?> projections = (Set<?>) result;
+		assertThat(projections, is(not(empty())));
+		
+		Object projection = projections.iterator().next();
+		assertThat(projection, is(instanceOf(Helper.class)));		
+	}
+	
 	interface Helper {
 
 		Helper getHelper();
@@ -102,5 +193,17 @@ public class ProjectingMethodInterceptorUnitTests {
 		String getString();
 
 		long getPrimitive();
+		
+		Collection<HelperProjection> getHelperCollection();
+		
+		List<HelperProjection> getHelperList();
+		
+		Set<HelperProjection> getHelperSet();
+	}
+	
+	interface HelperProjection {
+		Helper getHelper();
+
+		String getString();		
 	}
 }


### PR DESCRIPTION
When a projection has an attribute which is a collection of another projection, Spring Data REST is not populating the collection with projections but with entities. This patch allows Spring Data REST to apply projections to collection attributes as well.
