### PR TITLE
DATAREST-463 - Filter out ALPS metadata for fields and getters that are not exported

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-rest-parent</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATAREST-463-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data REST</name>

--- a/spring-data-rest-core/pom.xml
+++ b/spring-data-rest-core/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>2.3.0.BUILD-SNAPSHOT</version>
+		<version>2.3.0.DATAREST-463-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-rest-distribution/pom.xml
+++ b/spring-data-rest-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>2.3.0.BUILD-SNAPSHOT</version>
+		<version>2.3.0.DATAREST-463-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/spring-data-rest-webmvc/pom.xml
+++ b/spring-data-rest-webmvc/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>2.3.0.BUILD-SNAPSHOT</version>
+		<version>2.3.0.DATAREST-463-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/JacksonMetadata.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/JacksonMetadata.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
  * Value object to abstract Jackson based bean metadata of a given type.
  * 
  * @author Oliver Gierke
+ * @author Greg Turnquist
  */
 public class JacksonMetadata implements Iterable<BeanPropertyDefinition> {
 
@@ -72,6 +73,15 @@ public class JacksonMetadata implements Iterable<BeanPropertyDefinition> {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Check if a given property for a type is avaiaable to be exported, i.e. serialized via Jackson
+	 * @param property
+	 * @return
+	 */
+	public boolean isExportableProperty(PersistentProperty<?> property) {
+		return getDefinitionFor(property) != null;
 	}
 
 	/* 

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/mapping/AssociationLinks.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/mapping/AssociationLinks.java
@@ -31,6 +31,7 @@ import org.springframework.util.Assert;
  * A value object to for {@link Link}s representing an association.
  * 
  * @author Oliver Gierke
+ * @author Greg Turnquist
  * @since 2.1
  */
 public class AssociationLinks {
@@ -90,6 +91,7 @@ public class AssociationLinks {
 			return false;
 		}
 
+//		ResourceMetadata metadata = mappings.getMappingFor(property.getActualType());
 		ResourceMetadata metadata = mappings.getMappingFor(property.getOwner().getType());
 
 		if (metadata != null && !metadata.isExported(property)) {
@@ -99,4 +101,5 @@ public class AssociationLinks {
 		metadata = mappings.getMappingFor(property.getActualType());
 		return metadata == null ? false : metadata.isExported();
 	}
+
 }

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/RepositoryControllerIntegrationTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/RepositoryControllerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
  * Integration tests for {@link RepositoryController}.
  * 
  * @author Oliver Gierke
+ * @author Greg Turnquist
  */
 @ContextConfiguration(classes = JpaRepositoryConfig.class)
 @Transactional
@@ -57,12 +58,15 @@ public class RepositoryControllerIntegrationTests extends AbstractControllerInte
 		assertThat(controller.headForRepositories().getStatusCode(), is(HttpStatus.NO_CONTENT));
 	}
 
+	/**
+	 * @see DATAREST-160, DATAREST-333, DATAREST-463
+	 */
 	@Test
 	public void exposesLinksToRepositories() {
 
 		RepositoryLinksResource resource = controller.listRepositories().getBody();
 
-		assertThat(resource.getLinks(), hasSize(6));
+		assertThat(resource.getLinks(), hasSize(7));
 
 		assertThat(resource.hasLink("people"), is(true));
 		assertThat(resource.hasLink("orders"), is(true));
@@ -70,5 +74,6 @@ public class RepositoryControllerIntegrationTests extends AbstractControllerInte
 		assertThat(resource.hasLink("books"), is(true));
 		assertThat(resource.hasLink("authors"), is(true));
 		assertThat(resource.hasLink("receipts"), is(true));
+		assertThat(resource.hasLink("items"), is(true));
 	}
 }

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/jpa/Item.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/jpa/Item.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.webmvc.jpa;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * @author Greg Turnquist
+ * @see DATAREST-463
+ */
+@Entity
+public class Item {
+
+	@Id @GeneratedValue
+	private Long id;
+
+	private String name;
+
+	@JsonIgnore
+	@OneToOne
+	private User owner;
+
+	@OneToOne
+	private User manager;
+
+	@OneToOne
+	private User curator;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public User getOwner() {
+		return owner;
+	}
+
+	public void setOwner(User owner) {
+		this.owner = owner;
+	}
+
+	@JsonIgnore
+	public User getManager() {
+		return manager;
+	}
+
+	public void setManager(User manager) {
+		this.manager = manager;
+	}
+
+	public User getCurator() {
+		return curator;
+	}
+
+	public void setCurator(User curator) {
+		this.curator = curator;
+	}
+}

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/jpa/ItemRepository.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/jpa/ItemRepository.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.webmvc.jpa;
+
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * @author Greg Turnquist
+ * @see DATAREST-463
+ */
+public interface ItemRepository extends CrudRepository<Item, Long> {
+}

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/jpa/User.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/jpa/User.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.webmvc.jpa;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * @author Greg Turnquist
+ * @see DATAREST-463
+ */
+@Entity
+public class User {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    @JsonIgnore
+    private String password;
+
+    private String[] roles;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String[] getRoles() {
+        return roles;
+    }
+
+    public void setRoles(String... roles) {
+        this.roles = roles;
+    }
+}

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/jpa/UserRepository.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/jpa/UserRepository.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.webmvc.jpa;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+/**
+ * @author Greg Turnquist
+ * @see DATAREST-463
+ */
+@RepositoryRestResource(exported = false)
+public interface UserRepository extends CrudRepository<User, Long> {
+}


### PR DESCRIPTION
If @JsonIgnore is applied to either a field or a getter method for an association, then do not expose that property's metadata down from ALPS.