### PR TITLE
Datarest 34

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.6.0.RC1</version>
+		<version>1.6.0.BUILD-SNAPSHOT</version>
 		<relativePath>../spring-data-build/parent/pom.xml</relativePath>
 	</parent>
 
@@ -27,7 +27,7 @@
 		<project.type>multi</project.type>
 		<dist.id>spring-data-rest</dist.id>
 
-		<springdata.commons>1.10.0.RC1</springdata.commons>
+		<springdata.commons>1.10.0.BUILD-SNAPSHOT</springdata.commons>
 		<springdata.jpa>1.8.0.RC1</springdata.jpa>
 		<springdata.mongodb>1.7.0.RC1</springdata.mongodb>
 		<springdata.neo4j>3.3.0.RC1</springdata.neo4j>
@@ -154,8 +154,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-milestone</id>
-			<url>http://repo.spring.io/libs-milestone</url>
+			<id>spring-libs-snapshot</id>
+			<url>http://repo.spring.io/libs-snapshot</url>
 		</repository>
 	</repositories>
 

--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/config/RepositoryRestConfiguration.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/config/RepositoryRestConfiguration.java
@@ -296,7 +296,8 @@ public class RepositoryRestConfiguration {
 	/**
 	 * Whether to return a response body after creating an entity.
 	 * 
-	 * @return {@literal true} to return a body on create, {@literal false} otherwise. If null, defer to HTTP Accept header
+	 * @return {@link java.lang.Boolean#TRUE} to return a body on create, {@link java.lang.Boolean#FALSE} otherwise.
+	 * 				If {@literal null}, defer to HTTP Accept header
 	 */
 	public Boolean isReturnBodyOnCreate() {
 		return returnBodyOnCreate;
@@ -305,8 +306,8 @@ public class RepositoryRestConfiguration {
 	/**
 	 * Set whether to return a response body after creating an entity.
 	 * 
-	 * @param returnBodyOnCreate {@literal true} to return a body on create, {@literal false} otherwise.
-	 *                            Set to null in order to defer to HTTP Accept header
+	 * @param returnBodyOnCreate {@link java.lang.Boolean#TRUE} to return a body on create, {@link java.lang.Boolean#FALSE} otherwise.
+	 * 								If {@literal null}, defer to HTTP Accept header
 	 * @return {@literal this}
 	 */
 	public RepositoryRestConfiguration setReturnBodyOnCreate(Boolean returnBodyOnCreate) {
@@ -317,18 +318,19 @@ public class RepositoryRestConfiguration {
 	/**
 	 * Whether to return a response body after updating an entity.
 	 * 
-	 * @return {@literal true} to return a body on update, {@literal false} otherwise. If null, defer to HTTP Accept header
+	 * @return {@link java.lang.Boolean#TRUE} to return a body on update, {@link java.lang.Boolean#FALSE} otherwise.
+	 * 				If {@literal null}, defer to HTTP Accept header
 	 */
 	public Boolean isReturnBodyOnUpdate() {
 		return returnBodyOnUpdate;
 	}
 
 	/**
-	 * Sets whether to return a response body after updating an entity. Set to null in order to defer to HTTP Accept header
+	 * Set whether to return a response body after updating an entity.
+	 *
+	 * @param returnBodyOnUpdate {@link java.lang.Boolean#TRUE} to return a body on update, {@link java.lang.Boolean#FALSE} otherwise.
+	 * 								If {@literal null}, defer to HTTP Accept header
 	 * @return {@literal this}
-	 * 
-	 * @param returnBodyOnUpdate
-	 * @return
 	 */
 	public RepositoryRestConfiguration setReturnBodyOnUpdate(Boolean returnBodyOnUpdate) {
 		this.returnBodyOnUpdate = returnBodyOnUpdate;

--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/config/RepositoryRestConfiguration.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/config/RepositoryRestConfiguration.java
@@ -46,8 +46,8 @@ public class RepositoryRestConfiguration {
 	private String sortParamName = "sort";
 	private MediaType defaultMediaType = MediaTypes.HAL_JSON;
 	private boolean useHalAsDefaultJsonMediaType = true;
-	private boolean returnBodyOnCreate = false;
-	private boolean returnBodyOnUpdate = false;
+	private Boolean returnBodyOnCreate = Boolean.FALSE;
+	private Boolean returnBodyOnUpdate = Boolean.FALSE;
 	private List<Class<?>> exposeIdsFor = new ArrayList<Class<?>>();
 	private ResourceMappingConfiguration domainMappings = new ResourceMappingConfiguration();
 	private ResourceMappingConfiguration repoMappings = new ResourceMappingConfiguration();
@@ -296,9 +296,9 @@ public class RepositoryRestConfiguration {
 	/**
 	 * Whether to return a response body after creating an entity.
 	 * 
-	 * @return {@literal true} to return a body on create, {@literal false} otherwise.
+	 * @return {@literal true} to return a body on create, {@literal false} otherwise. If null, defer to HTTP Accept header
 	 */
-	public boolean isReturnBodyOnCreate() {
+	public Boolean isReturnBodyOnCreate() {
 		return returnBodyOnCreate;
 	}
 
@@ -306,9 +306,10 @@ public class RepositoryRestConfiguration {
 	 * Set whether to return a response body after creating an entity.
 	 * 
 	 * @param returnBodyOnCreate {@literal true} to return a body on create, {@literal false} otherwise.
+	 *                            Set to null in order to defer to HTTP Accept header
 	 * @return {@literal this}
 	 */
-	public RepositoryRestConfiguration setReturnBodyOnCreate(boolean returnBodyOnCreate) {
+	public RepositoryRestConfiguration setReturnBodyOnCreate(Boolean returnBodyOnCreate) {
 		this.returnBodyOnCreate = returnBodyOnCreate;
 		return this;
 	}
@@ -316,19 +317,20 @@ public class RepositoryRestConfiguration {
 	/**
 	 * Whether to return a response body after updating an entity.
 	 * 
-	 * @return {@literal true} to return a body on update, {@literal false} otherwise.
+	 * @return {@literal true} to return a body on update, {@literal false} otherwise. If null, defer to HTTP Accept header
 	 */
-	public boolean isReturnBodyOnUpdate() {
+	public Boolean isReturnBodyOnUpdate() {
 		return returnBodyOnUpdate;
 	}
 
 	/**
-	 * Sets whether to return a response body after updating an entity.
+	 * Sets whether to return a response body after updating an entity. Set to null in order to defer to HTTP Accept header
+	 * @return {@literal this}
 	 * 
 	 * @param returnBodyOnUpdate
 	 * @return
 	 */
-	public RepositoryRestConfiguration setReturnBodyOnUpdate(boolean returnBodyOnUpdate) {
+	public RepositoryRestConfiguration setReturnBodyOnUpdate(Boolean returnBodyOnUpdate) {
 		this.returnBodyOnUpdate = returnBodyOnUpdate;
 		return this;
 	}

--- a/src/main/asciidoc/repository-resources.adoc
+++ b/src/main/asciidoc/repository-resources.adoc
@@ -24,6 +24,8 @@ For the resources exposed, we use a set of default status codes:
 * `201 Created` - for `POST` and `PUT` requests that create new resources.
 * `204 No Content` - for `PUT`, `PATCH`, and `DELETE` requests if the configuration is set to not return response bodies for resource updates (`RepositoryRestConfiguration.returnBodyOnUpdate`). If the configuration value is set to include responses for `PUT`, `200 OK` will be returned for updates, `201 Created` will be returned for resource created through `PUT`.
 
+If the configuration values (`RepositoryRestConfiguration.returnBodyOnUpdate` and `RepositoryRestConfiguration.returnBodyCreate)` are explicitly set to null, the presence of the HTTP Accept header will be used to determine the response code.
+
 [[repository-resources.resource-discoverability]]
 === Resource discoverability
 


### PR DESCRIPTION
Issue: [DATAREST-34](https://jira.spring.io/browse/DATAREST-34)

As mentioned in [DATAREST-34](https://jira.spring.io/browse/DATAREST-34) and it's comments, this enhancement enables control of response body negotiation for PUT and POST requests through
the presence of the HTTP Accept header. RepositoryRestConfig.setReturnBodyOnCreate(…) and RepositoryRestConfig.setReturnBodyOnUpdate(…) were converted to Boolean and default to Boolean.FALSE. When set to null, the response body negotiation is controlled by the presence of the Accept header. 

For example:
curl -H "Content-Type: application/json" -d '{"id" : "cafebabe","vCenterId" : "cafebabe2","vCenterName" : "nuclab"}' http://localhost:8080/spring-data-rest-test-app-1.0-SNAPSHOT/clients

Returns:

{
  "id" : "cafebabe",
  "vCenterId" : "cafebabe2",
  "vCenterName" : "nuclab",
  "_links" : {
    "self" : {
      "href" : "http://localhost:8080/spring-data-rest-test-app-1.0-SNAPSHOT/clients/cafebabe"
    }
  }
}

While the following command returns no body:

curl -H "Content-Type: application/json" -H "Accept:" -d '{"id" : "cafebabe2","vCenterId" : "decafbad","vCenterName" : "the decaf lab"}' http://localhost:8080/spring-data-rest-test-app-1.0-SNAPSHOT/clients

I also corrected some of the Javadoc annotations in the RepositoryEntityController class.

I have signed and agree to the terms of the Spring Individual Contributor License Agreement.