### PR TITLE
Mark `getBaseUri()` with `@Deprecated`

### DIFF
--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/config/RepositoryRestConfiguration.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/config/RepositoryRestConfiguration.java
@@ -84,7 +84,9 @@ public class RepositoryRestConfiguration {
 	 * The base URI against which the exporter should calculate its links.
 	 * 
 	 * @return The base URI.
+	 * @deprecated use {@link #getBasePath()} instead.
 	 */
+	@Deprecated
 	public URI getBaseUri() {
 		return basePath != NO_URI ? basePath : baseUri;
 	}


### PR DESCRIPTION
I think deprecating `getBaseUri()` makes sense because `setBaseUri()`s are deprecated.