### PR TITLE
DATAREST-538 - Expose Jackson converter beans as being TypeConstrained

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
@@ -389,7 +389,7 @@ public class RepositoryRestMvcConfiguration extends HateoasAwareSpringDataWebCon
 	 * @return
 	 */
 	@Bean
-	public MappingJackson2HttpMessageConverter jacksonHttpMessageConverter() {
+	public TypeConstrainedMappingJackson2HttpMessageConverter jacksonHttpMessageConverter() {
 
 		List<MediaType> mediaTypes = new ArrayList<MediaType>();
 
@@ -405,7 +405,7 @@ public class RepositoryRestMvcConfiguration extends HateoasAwareSpringDataWebCon
 				RestMediaTypes.JSON_PATCH_JSON, RestMediaTypes.MERGE_PATCH_JSON, //
 				RestMediaTypes.SPRING_DATA_VERBOSE_JSON, RestMediaTypes.SPRING_DATA_COMPACT_JSON));
 
-		MappingJackson2HttpMessageConverter jacksonConverter = new ResourceSupportHttpMessageConverter(order);
+		TypeConstrainedMappingJackson2HttpMessageConverter jacksonConverter = new ResourceSupportHttpMessageConverter(order);
 		jacksonConverter.setObjectMapper(objectMapper());
 		jacksonConverter.setSupportedMediaTypes(mediaTypes);
 
@@ -417,7 +417,7 @@ public class RepositoryRestMvcConfiguration extends HateoasAwareSpringDataWebCon
 	//
 
 	@Bean
-	public MappingJackson2HttpMessageConverter halJacksonHttpMessageConverter() {
+	public TypeConstrainedMappingJackson2HttpMessageConverter halJacksonHttpMessageConverter() {
 
 		ArrayList<MediaType> mediaTypes = new ArrayList<MediaType>();
 		mediaTypes.add(MediaTypes.HAL_JSON);
@@ -430,7 +430,7 @@ public class RepositoryRestMvcConfiguration extends HateoasAwareSpringDataWebCon
 		int order = config().useHalAsDefaultJsonMediaType() ? Ordered.LOWEST_PRECEDENCE - 10
 				: Ordered.LOWEST_PRECEDENCE - 1;
 
-		MappingJackson2HttpMessageConverter converter = new ResourceSupportHttpMessageConverter(order);
+		TypeConstrainedMappingJackson2HttpMessageConverter converter = new ResourceSupportHttpMessageConverter(order);
 		converter.setObjectMapper(halObjectMapper());
 		converter.setSupportedMediaTypes(mediaTypes);
 


### PR DESCRIPTION
Previously, RepositoryRestMvcConfiguration exposed its two
ResourceSupportHttpMessageConverter beans as MappingJackson2HttpMessageConverters.
This made it impossible for Spring Boot support for conditional beans to identify
that they were type-constrained and, therefore, were not a suitable replacement
for a general-purpose Mapping Jackson2HttpMessageConverter bean.

This commit updates RepositoryRestMvcConfiguration to expose both of its Jackson
message converters as TypeConstrinaedMappingJackson2HttpMessageConverter instances.
This will also Spring Boot to identify that their converters are type-constrained
so that it can continue to auto-configure its general purpose converter. This is
important as it allows Boot to provide a converter that honours the user’s
configuration rather than Spring MVC’s default converter which does not. See
spring-projects/spring-boot#2914 for details.