### PR TITLE
Exception handler passes null instead of exception

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryRestExceptionHandler.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryRestExceptionHandler.java
@@ -95,7 +95,7 @@ public class RepositoryRestExceptionHandler {
 			ConversionFailedException.class, NullPointerException.class })
 	ResponseEntity<ExceptionMessage> handleMiscFailures(Exception o_O) {
 
-		return errorResponse(HttpStatus.INTERNAL_SERVER_ERROR, new HttpHeaders(), null);
+		return errorResponse(HttpStatus.INTERNAL_SERVER_ERROR, new HttpHeaders(), o_O);
 	}
 
 	/**


### PR DESCRIPTION
As a result exception is not logged and exception message is empty.