### PR TITLE
DATAREST-564 Fixed UnsupportedOperationException in getRepositoryLook…

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/BaseUri.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/BaseUri.java
@@ -18,6 +18,7 @@ package org.springframework.data.rest.webmvc;
 import static org.springframework.util.StringUtils.*;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -128,7 +129,7 @@ public class BaseUri {
 			return lookupPath.startsWith(uri) ? lookupPath.substring(uri.length(), lookupPath.length()) : null;
 		}
 
-		List<String> baseUriSegments = UriComponentsBuilder.fromUri(baseUri).build().getPathSegments();
+		List<String> baseUriSegments = new ArrayList<String>(UriComponentsBuilder.fromUri(baseUri).build().getPathSegments());
 		Collections.reverse(baseUriSegments);
 		String tail = "";
 

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/BaseUriUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/BaseUriUnitTests.java
@@ -96,4 +96,14 @@ public class BaseUriUnitTests {
 	public void repositoryLookupPathHandlesDoubleSlashes() {
 		assertThat(BaseUri.NONE.getRepositoryLookupPath("/books//1"), is("/books/1"));
 	}
+
+	/**
+	 * @see DATAREST-564
+	 */
+	@Test
+	public void repositoryLookupPathHandlesEmptyString() {
+		assertThat(BaseUri.NONE.getRepositoryLookupPath(""), isEmptyString());
+		assertThat(new BaseUri(URI.create("/foo")).getRepositoryLookupPath(""), is(nullValue()));
+		assertThat(new BaseUri(URI.create("http://localhost:8080/foo/")).getRepositoryLookupPath(""), is(nullValue()));
+	}
 }


### PR DESCRIPTION
…upPath with empty lookupPath

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.
