### PR TITLE
DATAREST-742: Fix embeddeds not working with require setters for getters configuration

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/PersistentEntityJackson2Module.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/PersistentEntityJackson2Module.java
@@ -46,6 +46,7 @@ import org.springframework.hateoas.UriTemplate;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -172,6 +173,7 @@ public class PersistentEntityJackson2Module extends SimpleModule {
 
 			Resource<Object> resourceToRender = new Resource<Object>(resource.getContent(), links) {
 
+				@JsonProperty
 				@JsonUnwrapped
 				public Iterable<?> getEmbedded() {
 					return resource.getEmbeddeds();


### PR DESCRIPTION
The embeddeds are not emitted for PersistedEntityResources when MapperFeature.REQUIRE_SETTERS_FOR_GETTERS is used. Add an explicit JsonProperty annotation to enforce JSON output for getEmbedded in the `PersistentEntityResourceSerializer`