### PR TITLE
Resolution for DATAREST-763

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/spi/BackendIdConverter.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/spi/BackendIdConverter.java
@@ -33,7 +33,7 @@ public interface BackendIdConverter extends Plugin<Class<?>> {
 	/**
 	 * Returns the id of the entity to be looked up eventually.
 	 *
-	 * @param id         the source id as it was parsed from the incoming request, will never be {@literal null}.
+	 * @param id the source id as it was parsed from the incoming request, will never be {@literal null}.
 	 * @param entityType the type of the object to be resolved, will never be {@literal null}.
 	 * @return must not be {@literal null}.
 	 */
@@ -42,7 +42,7 @@ public interface BackendIdConverter extends Plugin<Class<?>> {
 	/**
 	 * Returns the id to be used in the URI generated to point to an entity of the given type with the given id.
 	 *
-	 * @param id         the entity's id, will never be {@literal null}.
+	 * @param id the entity's id, will never be {@literal null}.
 	 * @param entityType the type of the entity to expose.
 	 * @return
 	 */

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/spi/BackendIdConverter.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/spi/BackendIdConverter.java
@@ -25,14 +25,14 @@ import org.springframework.plugin.core.Plugin;
 
 /**
  * SPI to allow the customization of how entity ids are exposed in URIs generated.
- *
+ * 
  * @author Oliver Gierke
  */
 public interface BackendIdConverter extends Plugin<Class<?>> {
 
 	/**
 	 * Returns the id of the entity to be looked up eventually.
-	 *
+	 * 
 	 * @param id the source id as it was parsed from the incoming request, will never be {@literal null}.
 	 * @param entityType the type of the object to be resolved, will never be {@literal null}.
 	 * @return must not be {@literal null}.
@@ -41,7 +41,7 @@ public interface BackendIdConverter extends Plugin<Class<?>> {
 
 	/**
 	 * Returns the id to be used in the URI generated to point to an entity of the given type with the given id.
-	 *
+	 * 
 	 * @param id the entity's id, will never be {@literal null}.
 	 * @param entityType the type of the entity to expose.
 	 * @return
@@ -50,12 +50,12 @@ public interface BackendIdConverter extends Plugin<Class<?>> {
 
 	/**
 	 * The default {@link BackendIdConverter} that will use URL encoding/decoding of ids to ensure valid URL generation.
-	 *
+	 * 
 	 * This class applies a simple UrlEncode/Decode to the presented id with the exception of any id which contains a
 	 * '/' character. Encoded '/'s are generally rejected by web servers (404) as a security risk. As it is perfectly
 	 * valid (though potentially a rare occurrence) for an id to contain '/'s, we avoid the issue by double encoding the
 	 * '/' --> %2F --> %252F.
-	 *
+	 * 
 	 * @author Oliver Gierke
 	 * @author Andrew Walters
 	 */
@@ -65,7 +65,7 @@ public interface BackendIdConverter extends Plugin<Class<?>> {
 
 		private static final String UTF8_ENCODING = "UTF-8";
 
-		/*
+		/* 
 		 * (non-Javadoc)
 		 * @see org.springframework.data.rest.webmvc.support.BackendIdConverter#fromRequestId(java.lang.String, java.lang.Class)
 		 */
@@ -78,7 +78,7 @@ public interface BackendIdConverter extends Plugin<Class<?>> {
 			}
 		}
 
-		/*
+		/* 
 		 * (non-Javadoc)
 		 * @see org.springframework.data.rest.webmvc.support.BackendIdConverter#toRequestId(java.lang.Object, java.lang.Class)
 		 */
@@ -91,7 +91,7 @@ public interface BackendIdConverter extends Plugin<Class<?>> {
 			}
 		}
 
-		/*
+		/* 
 		 * (non-Javadoc)
 		 * @see org.springframework.plugin.core.Plugin#supports(java.lang.Object)
 		 */

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/spi/BackendIdConverter.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/spi/BackendIdConverter.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,74 +30,74 @@ import org.springframework.plugin.core.Plugin;
  */
 public interface BackendIdConverter extends Plugin<Class<?>> {
 
-    /**
-     * Returns the id of the entity to be looked up eventually.
-     *
-     * @param id         the source id as it was parsed from the incoming request, will never be {@literal null}.
-     * @param entityType the type of the object to be resolved, will never be {@literal null}.
-     * @return must not be {@literal null}.
-     */
-    Serializable fromRequestId(String id, Class<?> entityType);
+	/**
+	 * Returns the id of the entity to be looked up eventually.
+	 *
+	 * @param id         the source id as it was parsed from the incoming request, will never be {@literal null}.
+	 * @param entityType the type of the object to be resolved, will never be {@literal null}.
+	 * @return must not be {@literal null}.
+	 */
+	Serializable fromRequestId(String id, Class<?> entityType);
 
-    /**
-     * Returns the id to be used in the URI generated to point to an entity of the given type with the given id.
-     *
-     * @param id         the entity's id, will never be {@literal null}.
-     * @param entityType the type of the entity to expose.
-     * @return
-     */
-    String toRequestId(Serializable id, Class<?> entityType);
+	/**
+	 * Returns the id to be used in the URI generated to point to an entity of the given type with the given id.
+	 *
+	 * @param id         the entity's id, will never be {@literal null}.
+	 * @param entityType the type of the entity to expose.
+	 * @return
+	 */
+	String toRequestId(Serializable id, Class<?> entityType);
 
-    /**
-     * The default {@link BackendIdConverter} that will use URL encoding/decoding of ids to ensure valid URL generation.
-     *
-     * This class applies a simple UrlEncode/Decode to the presented id with the exception of any id which contains a
-     * '/' character. Encoded '/'s are generally rejected by web servers (404) as a security risk. As it is perfectly
-     * valid (though potentially a rare occurrence) for an id to contain '/'s, we avoid the issue by double encoding the
-     * '/' --> %2F --> %252F.
-     *
-     * @author Oliver Gierke
-     * @author Andrew Walters
-     */
-    public enum DefaultIdConverter implements BackendIdConverter {
+	/**
+	 * The default {@link BackendIdConverter} that will use URL encoding/decoding of ids to ensure valid URL generation.
+	 *
+	 * This class applies a simple UrlEncode/Decode to the presented id with the exception of any id which contains a
+	 * '/' character. Encoded '/'s are generally rejected by web servers (404) as a security risk. As it is perfectly
+	 * valid (though potentially a rare occurrence) for an id to contain '/'s, we avoid the issue by double encoding the
+	 * '/' --> %2F --> %252F.
+	 *
+	 * @author Oliver Gierke
+	 * @author Andrew Walters
+	 */
+	public enum DefaultIdConverter implements BackendIdConverter {
 
-        INSTANCE;
+		INSTANCE;
 
-        private static final String UTF8_ENCODING = "UTF-8";
+		private static final String UTF8_ENCODING = "UTF-8";
 
-        /*
-         * (non-Javadoc)
-         * @see org.springframework.data.rest.webmvc.support.BackendIdConverter#fromRequestId(java.lang.String, java.lang.Class)
-         */
-        @Override
-        public Serializable fromRequestId(String id, Class<?> entityType) {
-            try {
-                return URLDecoder.decode(id, UTF8_ENCODING).replaceAll("%2F", "/");
-            } catch (UnsupportedEncodingException e) {
-                return id;
-            }
-        }
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.rest.webmvc.support.BackendIdConverter#fromRequestId(java.lang.String, java.lang.Class)
+		 */
+		@Override
+		public Serializable fromRequestId(String id, Class<?> entityType) {
+			try {
+				return URLDecoder.decode(id, UTF8_ENCODING).replaceAll("%2F", "/");
+			} catch (UnsupportedEncodingException e) {
+				return id;
+			}
+		}
 
-        /*
-         * (non-Javadoc)
-         * @see org.springframework.data.rest.webmvc.support.BackendIdConverter#toRequestId(java.lang.Object, java.lang.Class)
-         */
-        @Override
-        public String toRequestId(Serializable id, Class<?> entityType) {
-            try {
-                return URLEncoder.encode(id.toString(), UTF8_ENCODING).replaceAll("%2F", "%252F");
-            } catch (UnsupportedEncodingException e) {
-                return id.toString();
-            }
-        }
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.rest.webmvc.support.BackendIdConverter#toRequestId(java.lang.Object, java.lang.Class)
+		 */
+		@Override
+		public String toRequestId(Serializable id, Class<?> entityType) {
+			try {
+				return URLEncoder.encode(id.toString(), UTF8_ENCODING).replaceAll("%2F", "%252F");
+			} catch (UnsupportedEncodingException e) {
+				return id.toString();
+			}
+		}
 
-        /*
-         * (non-Javadoc)
-         * @see org.springframework.plugin.core.Plugin#supports(java.lang.Object)
-         */
-        @Override
-        public boolean supports(Class<?> entityType) {
-            return true;
-        }
-    }
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.plugin.core.Plugin#supports(java.lang.Object)
+		 */
+		@Override
+		public boolean supports(Class<?> entityType) {
+			return true;
+		}
+	}
 }

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/spi/DefaultIdConverterTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/spi/DefaultIdConverterTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.webmvc.spi;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import static org.springframework.data.rest.webmvc.spi.BackendIdConverter.DefaultIdConverter.INSTANCE;
+
+/**
+ * Unit tests for {@link BackendIdConverter.DefaultIdConverter}.
+ *
+ * @author Andrew Walters
+ */
+public class DefaultIdConverterTests {
+    /**
+     * @see DATAREST-763
+     */
+    @Test
+    public void idsForUseWithinAURIShouldEncodeSpaces() {
+        assertThat(INSTANCE.toRequestId("I contain spaces", Object.class), is("I+contain+spaces"));
+    }
+
+    /**
+     * @see DATAREST-763
+     */
+    @Test
+    public void idsForUseWithinAURIShouldEncodeSpacesAtEnd() {
+        assertThat(INSTANCE.toRequestId("I contain spaces   ", Object.class), is("I+contain+spaces+++"));
+    }
+
+    /**
+     * @see DATAREST-763
+     *
+     * This one is slightly more interesting - the %2F *may* be rejected by web servers as part of a generated URL
+     * Apache inparticular denies all URLs with %2F in the path part, for security reasons
+     * but we can't allow [raw] slashes to be present in an ID as paths could then be subverted - precisely the reason
+     * that Apache rejects the %2F.
+     *
+     * I'd propose double-encoding/decoding the '/' --> %2f --> %252f for maximum portability
+     */
+    @Test
+    public void idsForUseWithinAURIShouldEncodeToAvoidPathExploiting() {
+        assertThat(INSTANCE.toRequestId("I/contain/slashes", Object.class), is("I%252Fcontain%252Fslashes"));
+    }
+
+    /**
+     * @see DATAREST-763
+     */
+    @Test
+    public void idsForUseWithinAURIShouldEncodeQuestionMarkToAvoidQueryStringExploiting() {
+        assertThat(INSTANCE.toRequestId("IContainAQuestionMark?size=1000000", Object.class),
+                is("IContainAQuestionMark%3Fsize%3D1000000"));
+    }
+
+    /**
+     * @see DATAREST-763
+     */
+    @Test
+    public void idsForUseWithinAURIShouldDecodeQuestionMarks() {
+        assertThat((String)INSTANCE.fromRequestId("IContainAQuestionMark%3Fsize%3D1000000", Object.class),
+                is("IContainAQuestionMark?size=1000000"));
+    }
+
+    /**
+     * @see DATAREST-763
+     */
+    @Test
+    public void idsForUseWithinAURIShouldDecodeSlashes() {
+        assertThat((String)INSTANCE.fromRequestId("I%252Fcontain%252Fslashes", Object.class),
+                is("I/contain/slashes"));
+    }
+
+    /**
+     * @see DATAREST-763
+     */
+    @Test
+    public void idsForUseWithinAURIShouldDecodeSpaces() {
+        assertThat((String)INSTANCE.fromRequestId("I%20contain%20spaces", Object.class),
+                is("I contain spaces"));
+    }
+}

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/spi/DefaultIdConverterTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/spi/DefaultIdConverterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *	  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,74 +24,74 @@ import static org.springframework.data.rest.webmvc.spi.BackendIdConverter.Defaul
 
 /**
  * Unit tests for {@link BackendIdConverter.DefaultIdConverter}.
- *
+ * 
  * @author Andrew Walters
  */
 public class DefaultIdConverterTests {
-    /**
-     * @see DATAREST-763
-     */
-    @Test
-    public void idsForUseWithinAURIShouldEncodeSpaces() {
-        assertThat(INSTANCE.toRequestId("I contain spaces", Object.class), is("I+contain+spaces"));
-    }
+	/**
+	 * @see DATAREST-763
+	 */
+	@Test
+	public void idsForUseWithinAURIShouldEncodeSpaces() {
+		assertThat(INSTANCE.toRequestId("I contain spaces", Object.class), is("I+contain+spaces"));
+	}
 
-    /**
-     * @see DATAREST-763
-     */
-    @Test
-    public void idsForUseWithinAURIShouldEncodeSpacesAtEnd() {
-        assertThat(INSTANCE.toRequestId("I contain spaces   ", Object.class), is("I+contain+spaces+++"));
-    }
+	/**
+	 * @see DATAREST-763
+	 */
+	@Test
+	public void idsForUseWithinAURIShouldEncodeSpacesAtEnd() {
+		assertThat(INSTANCE.toRequestId("I contain spaces   ", Object.class), is("I+contain+spaces+++"));
+	}
 
-    /**
-     * @see DATAREST-763
-     *
-     * This one is slightly more interesting - the %2F *may* be rejected by web servers as part of a generated URL
-     * Apache inparticular denies all URLs with %2F in the path part, for security reasons
-     * but we can't allow [raw] slashes to be present in an ID as paths could then be subverted - precisely the reason
-     * that Apache rejects the %2F.
-     *
-     * I'd propose double-encoding/decoding the '/' --> %2f --> %252f for maximum portability
-     */
-    @Test
-    public void idsForUseWithinAURIShouldEncodeToAvoidPathExploiting() {
-        assertThat(INSTANCE.toRequestId("I/contain/slashes", Object.class), is("I%252Fcontain%252Fslashes"));
-    }
+	/**
+	 * @see DATAREST-763
+	 * 
+	 * This one is slightly more interesting - the %2F *may* be rejected by web servers as part of a generated URL
+	 * Apache inparticular denies all URLs with %2F in the path part, for security reasons
+	 * but we can't allow [raw] slashes to be present in an ID as paths could then be subverted - precisely the reason
+	 * that Apache rejects the %2f.
+	 * 
+	 * I'd propose double-encoding/decoding the '/' --> %2f --> %252f for maximum portability
+	 */
+	@Test
+	public void idsForUseWithinAURIShouldEncodeToAvoidPathExploiting() {
+		assertThat(INSTANCE.toRequestId("I/contain/slashes", Object.class), is("I%252Fcontain%252Fslashes"));
+	}
 
-    /**
-     * @see DATAREST-763
-     */
-    @Test
-    public void idsForUseWithinAURIShouldEncodeQuestionMarkToAvoidQueryStringExploiting() {
-        assertThat(INSTANCE.toRequestId("IContainAQuestionMark?size=1000000", Object.class),
-                is("IContainAQuestionMark%3Fsize%3D1000000"));
-    }
+	/**
+	 * @see DATAREST-763
+	 */
+	@Test
+	public void idsForUseWithinAURIShouldEncodeQuestionMarkToAvoidQueryStringExploiting() {
+		assertThat(INSTANCE.toRequestId("IContainAQuestionMark?size=1000000", Object.class),
+				is("IContainAQuestionMark%3Fsize%3D1000000"));
+	}
 
-    /**
-     * @see DATAREST-763
-     */
-    @Test
-    public void idsForUseWithinAURIShouldDecodeQuestionMarks() {
-        assertThat((String)INSTANCE.fromRequestId("IContainAQuestionMark%3Fsize%3D1000000", Object.class),
-                is("IContainAQuestionMark?size=1000000"));
-    }
+	/**
+	 * @see DATAREST-763
+	 */
+	@Test
+	public void idsForUseWithinAURIShouldDecodeQuestionMarks() {
+		assertThat((String)INSTANCE.fromRequestId("IContainAQuestionMark%3Fsize%3D1000000", Object.class),
+				is("IContainAQuestionMark?size=1000000"));
+	}
 
-    /**
-     * @see DATAREST-763
-     */
-    @Test
-    public void idsForUseWithinAURIShouldDecodeSlashes() {
-        assertThat((String)INSTANCE.fromRequestId("I%252Fcontain%252Fslashes", Object.class),
-                is("I/contain/slashes"));
-    }
+	/**
+	 * @see DATAREST-763
+	 */
+	@Test
+	public void idsForUseWithinAURIShouldDecodeSlashes() {
+		assertThat((String)INSTANCE.fromRequestId("I%252Fcontain%252Fslashes", Object.class),
+				is("I/contain/slashes"));
+	}
 
-    /**
-     * @see DATAREST-763
-     */
-    @Test
-    public void idsForUseWithinAURIShouldDecodeSpaces() {
-        assertThat((String)INSTANCE.fromRequestId("I%20contain%20spaces", Object.class),
-                is("I contain spaces"));
-    }
+	/**
+	 * @see DATAREST-763
+	 */
+	@Test
+	public void idsForUseWithinAURIShouldDecodeSpaces() {
+		assertThat((String)INSTANCE.fromRequestId("I%20contain%20spaces", Object.class),
+				is("I contain spaces"));
+	}
 }


### PR DESCRIPTION
Unit tests and code fix for DATAREST-763.

Apologies I am unable to squash the commits at present as I'm working through the web UI due to access restrictions to gitHub.

This fix URL encodes/decodes entity ids to prevent the potential for invalid characters ending up in the URL. This is simply a case of encode/decode for all characters save for '/' which in its encoded form of %2F is not accepted by most webservers due to security issues (allowing for spurious modification of paths - partly what this change addresses from the DATAREST side!)

The proposed solution for this specific case is to double encode and decode the / --> %2F --> %252F which avoids this issue.
