### PR TITLE
DATAREST-836 Provide ability to handle 'after' Http findOne event

### DIFF
--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/annotation/HandleAfterFindOne.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/annotation/HandleAfterFindOne.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.core.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Pavel Varchenko
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface HandleAfterFindOne {
+}

--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/event/AfterFindOneEvent.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/event/AfterFindOneEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.core.event;
+
+/**
+ * Emitted after entity was found by Id.
+ *
+ * @author Pavel Varchenko
+ */
+public class AfterFindOneEvent extends RepositoryEvent {
+
+    public AfterFindOneEvent(Object source) {
+        super(source);
+    }
+}

--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/event/AnnotatedEventHandlerInvoker.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/event/AnnotatedEventHandlerInvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.data.rest.core.annotation.HandleAfterCreate;
 import org.springframework.data.rest.core.annotation.HandleAfterDelete;
+import org.springframework.data.rest.core.annotation.HandleAfterFindOne;
 import org.springframework.data.rest.core.annotation.HandleAfterLinkDelete;
 import org.springframework.data.rest.core.annotation.HandleAfterLinkSave;
 import org.springframework.data.rest.core.annotation.HandleAfterSave;
@@ -49,6 +50,7 @@ import org.springframework.util.ReflectionUtils;
  * 
  * @author Jon Brisbin
  * @author Oliver Gierke
+ * @author Pavel Varchenko
  */
 public class AnnotatedEventHandlerInvoker implements ApplicationListener<RepositoryEvent>, BeanPostProcessor {
 
@@ -135,6 +137,7 @@ public class AnnotatedEventHandlerInvoker implements ApplicationListener<Reposit
 				inspect(bean, method, HandleAfterDelete.class, AfterDeleteEvent.class);
 				inspect(bean, method, HandleBeforeLinkDelete.class, BeforeLinkDeleteEvent.class);
 				inspect(bean, method, HandleAfterLinkDelete.class, AfterLinkDeleteEvent.class);
+				inspect(bean, method, HandleAfterFindOne.class, AfterFindOneEvent.class);
 			}
 		}, Methods.USER_METHODS);
 

--- a/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/context/RepositoryEventIntegrationTests.java
+++ b/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/context/RepositoryEventIntegrationTests.java
@@ -31,6 +31,7 @@ import org.springframework.data.rest.core.domain.PersonBeforeSaveHandler;
 import org.springframework.data.rest.core.domain.PersonRepository;
 import org.springframework.data.rest.core.event.AfterCreateEvent;
 import org.springframework.data.rest.core.event.AfterDeleteEvent;
+import org.springframework.data.rest.core.event.AfterFindOneEvent;
 import org.springframework.data.rest.core.event.AfterLinkDeleteEvent;
 import org.springframework.data.rest.core.event.AfterLinkSaveEvent;
 import org.springframework.data.rest.core.event.AfterSaveEvent;
@@ -48,6 +49,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * 
  * @author Jon Brisbin
  * @author Oliver Gierke
+ * @author Pavel Varchenko
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -160,5 +162,13 @@ public class RepositoryEventIntegrationTests {
 	@Test(expected = EventHandlerInvokedException.class)
 	public void shouldDispatchAfterLinkDelete() throws Exception {
 		appCtx.publishEvent(new AfterLinkDeleteEvent(person, new Object()));
+	}
+
+	/**
+	 * @see DATAREST-836
+	 */
+	@Test(expected = EventHandlerInvokedException.class)
+	public void shouldDispatchAfterFindOne() throws Exception {
+		appCtx.publishEvent(new AfterFindOneEvent(person));
 	}
 }

--- a/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/domain/AnnotatedPersonEventHandler.java
+++ b/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/domain/AnnotatedPersonEventHandler.java
@@ -15,23 +15,14 @@
  */
 package org.springframework.data.rest.core.domain;
 
-import org.springframework.data.rest.core.annotation.HandleAfterCreate;
-import org.springframework.data.rest.core.annotation.HandleAfterDelete;
-import org.springframework.data.rest.core.annotation.HandleAfterLinkDelete;
-import org.springframework.data.rest.core.annotation.HandleAfterLinkSave;
-import org.springframework.data.rest.core.annotation.HandleAfterSave;
-import org.springframework.data.rest.core.annotation.HandleBeforeCreate;
-import org.springframework.data.rest.core.annotation.HandleBeforeDelete;
-import org.springframework.data.rest.core.annotation.HandleBeforeLinkDelete;
-import org.springframework.data.rest.core.annotation.HandleBeforeLinkSave;
-import org.springframework.data.rest.core.annotation.HandleBeforeSave;
-import org.springframework.data.rest.core.annotation.RepositoryEventHandler;
+import org.springframework.data.rest.core.annotation.*;
 
 /**
  * Sample annotation-based event handler.
  * 
  * @author Jon Brisbin
  * @author Oliver Gierke
+ * @author Pavel Varchenko
  */
 @RepositoryEventHandler
 public class AnnotatedPersonEventHandler {
@@ -39,6 +30,7 @@ public class AnnotatedPersonEventHandler {
 	@HandleAfterCreate
 	@HandleAfterDelete
 	@HandleAfterSave
+	@HandleAfterFindOne
 	public void handleAfter(Person p) {
 		throw new EventHandlerInvokedException();
 	}

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryEntityController.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryEntityController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.data.repository.support.RepositoryInvoker;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.core.event.AfterCreateEvent;
 import org.springframework.data.rest.core.event.AfterDeleteEvent;
+import org.springframework.data.rest.core.event.AfterFindOneEvent;
 import org.springframework.data.rest.core.event.AfterSaveEvent;
 import org.springframework.data.rest.core.event.BeforeCreateEvent;
 import org.springframework.data.rest.core.event.BeforeDeleteEvent;
@@ -75,6 +76,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
  * @author Oliver Gierke
  * @author Greg Turnquist
  * @author Jeremy Rickard
+ * @author Pavel Varchenko
  */
 @RepositoryRestController
 class RepositoryEntityController extends AbstractRepositoryRestController implements ApplicationEventPublisherAware {
@@ -313,6 +315,7 @@ class RepositoryEntityController extends AbstractRepositoryRestController implem
 		if (domainObject == null) {
 			throw new ResourceNotFoundException();
 		}
+		publisher.publishEvent(new AfterFindOneEvent(domainObject));
 
 		Links links = new Links(assembler.toResource(domainObject).getLinks());
 


### PR DESCRIPTION
At the moment to read item resource by ID spring data rest uses JPA repository 'findOne' method.
There are some different use cases to use this method:
1. Custom jackson deserializer (via RepositoryInvoker.invokeFindOne())
2. Spring data rest RepositoryEntityController (via RepositoryInvoker.invokeFindOne())
3. Another application business logic (via JPA repository)
In some use cases we need
1. To secure findOne
2. To count usage of findOne from HTTP requests
Provide security via findOne in some cases make different troubles (deserialization an entity to object by ID) and may be unnecessary.
In this issue I suggest to implement HandleAfterFindOne annotation and AfterFindOneEvent event and publish them in RepositoryEntityController. So we could use annotated handlers
