### PR TITLE
DATAREST-930: fixed little typos in code snippets

### DIFF
--- a/src/main/asciidoc/getting-started.adoc
+++ b/src/main/asciidoc/getting-started.adoc
@@ -120,7 +120,7 @@ class CustomRestMvcConfiguration {
 
       @Override
       public void configureRepositoryRestConfiguration(RepositoryRestConfiguration config) {
-        configuration.setBasePath("/api")
+        config.setBasePath("/api");
       }
     };
   }
@@ -136,7 +136,7 @@ public class CustomizedRestMvcConfiguration extends RepositoryRestConfigurerAdap
 
   @Override
   public void configureRepositoryRestConfiguration(RepositoryRestConfiguration config) {
-    configuration.setBasePath("/api")
+    config.setBasePath("/api");
   }
 }
 ----


### PR DESCRIPTION
The code snippet in the documentation contained minor syntax errors.
