### PR TITLE
DATACMNS-918, DATAREST-910 - Support nested Sort properties.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-rest-parent</artifactId>
-	<version>2.6.0.BUILD-SNAPSHOT</version>
+	<version>2.6.0.DATACMNS-918-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data REST</name>
@@ -28,7 +28,7 @@
 		<project.type>multi</project.type>
 		<dist.id>spring-data-rest</dist.id>
 
-		<springdata.commons>1.13.0.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>1.13.0.DATACMNS-918-SNAPSHOT</springdata.commons>
 		<springdata.jpa>1.11.0.BUILD-SNAPSHOT</springdata.jpa>
 		<springdata.mongodb>1.10.0.BUILD-SNAPSHOT</springdata.mongodb>
 		<springdata.gemfire>1.9.0.BUILD-SNAPSHOT</springdata.gemfire>

--- a/spring-data-rest-core/pom.xml
+++ b/spring-data-rest-core/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATACMNS-918-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-rest-distribution/pom.xml
+++ b/spring-data-rest-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATACMNS-918-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/spring-data-rest-hal-browser/pom.xml
+++ b/spring-data-rest-hal-browser/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATACMNS-918-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-data-rest-hal-browser</artifactId>

--- a/spring-data-rest-tests/pom.xml
+++ b/spring-data-rest-tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATACMNS-918-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -41,6 +41,12 @@
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy-all</artifactId>
 			<version>${groovy.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-commons</artifactId>
+			<version>1.13.0.DATACMNS-918-SNAPSHOT</version>
 		</dependency>
 
 	</dependencies>

--- a/spring-data-rest-tests/spring-data-rest-tests-core/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATACMNS-918-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-webmvc</artifactId>
-			<version>2.6.0.BUILD-SNAPSHOT</version>
+			<version>2.6.0.DATACMNS-918-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-rest-tests/spring-data-rest-tests-gemfire/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-gemfire/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATACMNS-918-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>2.6.0.BUILD-SNAPSHOT</version>
+			<version>2.6.0.DATACMNS-918-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATACMNS-918-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>2.6.0.BUILD-SNAPSHOT</version>
+			<version>2.6.0.DATACMNS-918-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaRepositoryConfig.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaRepositoryConfig.java
@@ -17,8 +17,12 @@ package org.springframework.data.rest.webmvc.jpa;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
+import org.springframework.data.rest.webmvc.RepositoryRestController;
+import org.springframework.data.rest.webmvc.support.DefaultedPageable;
 import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -30,6 +34,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
  * 
  * @author Jon Brisbin
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 @Configuration
 @EnableJpaRepositories
@@ -50,6 +55,14 @@ public class JpaRepositoryConfig extends JpaInfrastructureConfig {
 	static class BooksHtmlController {
 
 		@RequestMapping(value = "/books/{id}", method = RequestMethod.GET, produces = MediaType.TEXT_HTML_VALUE)
-		void person(@PathVariable String id) {}
+		void someMethod(@PathVariable String id) {}
+	}
+
+	@RepositoryRestController
+	@RequestMapping("orders")
+	static class OrdersJsonController {
+
+		@RequestMapping(value = "/search/sort", method = RequestMethod.POST, produces = "application/hal+json")
+		void someMethodWithArgs(Sort sort, Pageable pageable, DefaultedPageable defaultedPageable) {}
 	}
 }

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaWebTests.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaWebTests.java
@@ -702,6 +702,16 @@ public class JpaWebTests extends CommonWebTests {
 				andExpect(client.hasLinkWithRel("self"));
 	}
 
+	/**
+	 * @see DATAREST-910
+	 */
+	@Test
+	public void callUnmappedCustomRepositoryController() throws Exception {
+
+		mvc.perform(post("/orders/search/sort")).andExpect(status().isOk());
+		mvc.perform(post("/orders/search/sort?sort=type&page=1&size=10")).andExpect(status().isOk());
+	}
+
 	private List<Link> preparePersonResources(Person primary, Person... persons) throws Exception {
 
 		Link peopleLink = client.discoverUnique("people");

--- a/spring-data-rest-tests/spring-data-rest-tests-mongodb/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-mongodb/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATACMNS-918-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>2.6.0.BUILD-SNAPSHOT</version>
+			<version>2.6.0.DATACMNS-918-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-security/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-security/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATACMNS-918-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>2.6.0.BUILD-SNAPSHOT</version>
+			<version>2.6.0.DATACMNS-918-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-shop/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-shop/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATACMNS-918-SNAPSHOT</version>
 	</parent>
 
 	<name>Spring Data REST Tests - Shop</name>

--- a/spring-data-rest-tests/spring-data-rest-tests-solr/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-solr/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATACMNS-918-SNAPSHOT</version>
 	</parent>
 
 	<name>Spring Data REST Tests - Solr</name>
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>2.6.0.BUILD-SNAPSHOT</version>
+			<version>2.6.0.DATACMNS-918-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-webmvc/pom.xml
+++ b/spring-data-rest-webmvc/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATACMNS-918-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
@@ -807,7 +807,7 @@ public class RepositoryRestMvcConfiguration extends HateoasAwareSpringDataWebCon
 		PageableHandlerMethodArgumentResolver pageableResolver = pageableResolver();
 
 		JacksonMappingAwareSortTranslator sortTranslator = new JacksonMappingAwareSortTranslator(objectMapper(),
-				repositories(), DomainClassResolver.of(repositories(), resourceMappings(), baseUri()));
+				repositories(), DomainClassResolver.of(repositories(), resourceMappings(), baseUri()), persistentEntities());
 
 		HandlerMethodArgumentResolver sortResolver = new MappingAwareSortArgumentResolver(sortTranslator, sortResolver());
 		HandlerMethodArgumentResolver jacksonPageableResolver = new MappingAwarePageableArgumentResolver(sortTranslator,

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
@@ -117,6 +117,7 @@ import org.springframework.data.rest.webmvc.support.RepositoryEntityLinks;
 import org.springframework.data.util.AnnotatedTypeScanner;
 import org.springframework.data.web.HateoasPageableHandlerMethodArgumentResolver;
 import org.springframework.data.web.HateoasSortHandlerMethodArgumentResolver;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.data.web.config.HateoasAwareSpringDataWebConfiguration;
 import org.springframework.data.web.config.SpringDataJacksonConfiguration;
@@ -803,7 +804,7 @@ public class RepositoryRestMvcConfiguration extends HateoasAwareSpringDataWebCon
 				persistentEntities(), selfLinkProvider(), config().getProjectionConfiguration(), projectionFactory,
 				associationLinks());
 
-		HateoasPageableHandlerMethodArgumentResolver pageableResolver = pageableResolver();
+		PageableHandlerMethodArgumentResolver pageableResolver = pageableResolver();
 
 		JacksonMappingAwareSortTranslator sortTranslator = new JacksonMappingAwareSortTranslator(objectMapper(),
 				repositories(), DomainClassResolver.of(repositories(), resourceMappings(), baseUri()));

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/MappingAwareDefaultedPageableArgumentResolver.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/MappingAwareDefaultedPageableArgumentResolver.java
@@ -39,7 +39,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
  *
  * @author Mark Paluch
  * @author Oliver Gierke
- * @since 2.6, 2.5.3
+ * @since 2.6
  */
 @RequiredArgsConstructor
 public class MappingAwareDefaultedPageableArgumentResolver implements HandlerMethodArgumentResolver {

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/MappingAwarePageableArgumentResolver.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/MappingAwarePageableArgumentResolver.java
@@ -22,15 +22,15 @@ import org.springframework.core.MethodParameter;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.data.web.PageableArgumentResolver;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 /**
- * {@link HandlerMethodArgumentResolver} to resolve {@link Pageable} from a
- * {@link PageableHandlerMethodArgumentResolver} applying field to property mapping.
+ * {@link HandlerMethodArgumentResolver} to resolve {@link Pageable} from a {@link PageableArgumentResolver} applying
+ * field to property mapping.
  * <p>
  * A resolved {@link Pageable} is post-processed by applying Jackson field-to-property mapping if it contains a
  * {@link Sort} instance. Customized fields are resolved to their property names. Unknown properties are removed from
@@ -38,13 +38,13 @@ import org.springframework.web.method.support.ModelAndViewContainer;
  * 
  * @author Mark Paluch
  * @author Oliver Gierke
- * @since 2.6, 2.5.3
+ * @since 2.6
  */
 @RequiredArgsConstructor
-public class MappingAwarePageableArgumentResolver implements HandlerMethodArgumentResolver {
+public class MappingAwarePageableArgumentResolver implements HandlerMethodArgumentResolver, PageableArgumentResolver {
 
 	private final @NonNull JacksonMappingAwareSortTranslator translator;
-	private final @NonNull PageableHandlerMethodArgumentResolver delegate;
+	private final @NonNull PageableArgumentResolver delegate;
 
 	/*
 	 * (non-Javadoc)
@@ -57,20 +57,19 @@ public class MappingAwarePageableArgumentResolver implements HandlerMethodArgume
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.web.method.support.HandlerMethodArgumentResolver#resolveArgument(org.springframework.core.MethodParameter, org.springframework.web.method.support.ModelAndViewContainer, org.springframework.web.context.request.NativeWebRequest, org.springframework.web.bind.support.WebDataBinderFactory)
+	 * @see org.springframework.data.web.PageableArgumentResolver#resolveArgument(org.springframework.core.MethodParameter, org.springframework.web.method.support.ModelAndViewContainer, org.springframework.web.context.request.NativeWebRequest, org.springframework.web.bind.support.WebDataBinderFactory)
 	 */
 	@Override
-	public Pageable resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
-			NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+	public Pageable resolveArgument(MethodParameter methodParameter, ModelAndViewContainer mavContainer,
+			NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
 
-		Pageable pageable = delegate.resolveArgument(parameter, mavContainer, webRequest, binderFactory);
+		Pageable pageable = delegate.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
 
 		if (pageable == null || pageable.getSort() == null) {
 			return pageable;
 		}
 
-		Sort translated = translator.translateSort(pageable.getSort(), parameter, webRequest);
+		Sort translated = translator.translateSort(pageable.getSort(), methodParameter, webRequest);
 		return new PageRequest(pageable.getPageNumber(), pageable.getPageSize(), translated);
 	}
-
 }

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/MappingAwareSortArgumentResolver.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/MappingAwareSortArgumentResolver.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.web.SortArgumentResolver;
 import org.springframework.data.web.SortHandlerMethodArgumentResolver;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -35,13 +36,13 @@ import org.springframework.web.method.support.ModelAndViewContainer;
  * 
  * @author Mark Paluch
  * @author Oliver Gierke
- * @since 2.6, 2.5.3
+ * @since 2.6
  */
 @RequiredArgsConstructor
-public class MappingAwareSortArgumentResolver implements HandlerMethodArgumentResolver {
+public class MappingAwareSortArgumentResolver implements HandlerMethodArgumentResolver, SortArgumentResolver {
 
 	private final @NonNull JacksonMappingAwareSortTranslator translator;
-	private final @NonNull SortHandlerMethodArgumentResolver delegate;
+	private final @NonNull SortArgumentResolver delegate;
 
 	/*
 	 * (non-Javadoc)
@@ -57,11 +58,11 @@ public class MappingAwareSortArgumentResolver implements HandlerMethodArgumentRe
 	 * @see org.springframework.web.method.support.HandlerMethodArgumentResolver#resolveArgument(org.springframework.core.MethodParameter, org.springframework.web.method.support.ModelAndViewContainer, org.springframework.web.context.request.NativeWebRequest, org.springframework.web.bind.support.WebDataBinderFactory)
 	 */
 	@Override
-	public Sort resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
-			NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+	public Sort resolveArgument(MethodParameter methodParameter, ModelAndViewContainer mavContainer,
+			NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
 
-		Sort sort = delegate.resolveArgument(parameter, mavContainer, webRequest, binderFactory);
+		Sort sort = delegate.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
 
-		return sort == null ? null : translator.translateSort(sort, parameter, webRequest);
+		return sort == null ? null : translator.translateSort(sort, methodParameter, webRequest);
 	}
 }

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/WrappedProperties.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/WrappedProperties.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.rest.webmvc.json;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mapping.context.PersistentEntities;
+import org.springframework.util.Assert;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.introspect.BasicClassIntrospector;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+import com.fasterxml.jackson.databind.introspect.ClassIntrospector;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import com.fasterxml.jackson.databind.util.NameTransformer;
+
+/**
+ * Simple value object to capture a mapping of Jackson mapped field names using
+ * {@link com.fasterxml.jackson.annotation.JsonUnwrapped} and {@link PersistentProperty} instances.
+ *
+ * @author Mark Paluch
+ * @since 2.6
+ */
+class WrappedProperties {
+
+	private static final ClassIntrospector INTROSPECTOR = new BasicClassIntrospector();
+	private static final AnnotationIntrospector ANNOTATION_INTROSPECTOR = new JacksonAnnotationIntrospector();
+
+	private final Map<String, List<PersistentProperty<?>>> fieldNameToProperties;
+
+	/**
+	 * Creates a new {@link WrappedProperties} instance for the given {@code fieldNameToProperties}.
+	 *
+	 * @param fieldNameToProperties must not be {@literal null}.
+	 */
+	private WrappedProperties(Map<String, List<PersistentProperty<?>>> fieldNameToProperties) {
+		this.fieldNameToProperties = new HashMap<String, List<PersistentProperty<?>>>(fieldNameToProperties);
+	}
+
+	/**
+	 * Creates {@link WrappedProperties} for the given {@link PersistentEntities} and {@link PersistentEntity}.
+	 *
+	 * @param persistentEntities must not be {@literal null}.
+	 * @param entity must not be {@literal null}.
+	 * @param mapper must not be {@literal null}.
+	 * @return
+	 */
+	public static WrappedProperties fromJacksonProperties(PersistentEntities persistentEntities,
+			PersistentEntity<?, ?> entity, ObjectMapper mapper) {
+
+		Assert.notNull(entity, "PersistentEntity must not be null!");
+
+		JacksonUnwrappedPropertiesResolver resolver = new JacksonUnwrappedPropertiesResolver(persistentEntities, mapper);
+		return new WrappedProperties(resolver.findUnwrappedPropertyPaths(entity.getType()));
+	}
+
+	/**
+	 * @param fieldName must not be empty or {@literal null}.
+	 * @return {@literal true} if the field name resolves to a {@literal PersistentProperty}.
+	 */
+	public boolean hasPersistentPropertiesForField(String fieldName) {
+
+		Assert.hasText(fieldName, "Field name must not be null or empty!");
+		return fieldNameToProperties.containsKey(fieldName);
+	}
+
+	/**
+	 * @param fieldName must not be empty or {@literal null}.
+	 * @return
+	 */
+	public List<PersistentProperty<?>> getPersistentProperties(String fieldName) {
+
+		Assert.hasText(fieldName, "Field name must not be null or empty!");
+
+		return hasPersistentPropertiesForField(fieldName)
+				? Collections.unmodifiableList(fieldNameToProperties.get(fieldName))
+				: Collections.<PersistentProperty<?>> emptyList();
+	}
+
+	/**
+	 * This class resolves {@code @JsonUnwrapped} field names to a list of involved {@link PersistentProperty properties}.
+	 * 
+	 * @author Mark Paluch
+	 */
+	@RequiredArgsConstructor
+	static class JacksonUnwrappedPropertiesResolver {
+
+		final @NonNull PersistentEntities persistentEntities;
+		final @NonNull ObjectMapper mapper;
+
+		/**
+		 * Resolve {@code @JsonUnwrapped} field names to a list of involved {@link PersistentProperty properties}.
+		 *
+		 * @param type must not be {@literal null}.
+		 * @return
+		 */
+		public Map<String, List<PersistentProperty<?>>> findUnwrappedPropertyPaths(Class<?> type) {
+
+			Assert.notNull(type, "Type must not be null!");
+
+			return findUnwrappedPropertyPaths(type, NameTransformer.NOP, false);
+		}
+
+		private Map<String, List<PersistentProperty<?>>> findUnwrappedPropertyPaths(Class<?> type,
+				NameTransformer nameTransformer, boolean considerRegularProperties) {
+
+			PersistentEntity<?, ?> entity = persistentEntities.getPersistentEntity(type);
+
+			if (entity == null) {
+				return Collections.emptyMap();
+			}
+
+			Map<String, List<PersistentProperty<?>>> mapping = new HashMap<String, List<PersistentProperty<?>>>();
+
+			for (BeanPropertyDefinition property : getMappedProperties(entity)) {
+
+				AnnotatedMember annotatedMember = findAnnotatedMember(property);
+
+				PersistentProperty<?> persistentProperty = entity.getPersistentProperty(property.getInternalName());
+
+				if (isJsonUnwrapped(annotatedMember)) {
+					mapping.putAll(findUnwrappedPropertyPaths(nameTransformer, annotatedMember, persistentProperty));
+				} else if (considerRegularProperties) {
+					mapping.put(nameTransformer.transform(property.getName()),
+							Collections.<PersistentProperty<?>> singletonList(persistentProperty));
+				}
+			}
+
+			return mapping;
+		}
+
+		private Map<String, List<PersistentProperty<?>>> findUnwrappedPropertyPaths(NameTransformer nameTransformer,
+				AnnotatedMember annotatedMember, PersistentProperty<?> persistentProperty) {
+
+			Map<String, List<PersistentProperty<?>>> mapping = new HashMap<String, List<PersistentProperty<?>>>();
+
+			NameTransformer propertyNameTransformer = NameTransformer.chainedTransformer(nameTransformer,
+					ANNOTATION_INTROSPECTOR.findUnwrappingNameTransformer(annotatedMember));
+
+			Map<String, List<PersistentProperty<?>>> nestedProperties = findUnwrappedPropertyPaths(
+					annotatedMember.getRawType(), propertyNameTransformer, true);
+
+			for (String key : nestedProperties.keySet()) {
+
+				List<PersistentProperty<?>> persistentProperties = new ArrayList<PersistentProperty<?>>();
+
+				persistentProperties.add(persistentProperty);
+				persistentProperties.addAll(nestedProperties.get(key));
+
+				mapping.put(key, persistentProperties);
+			}
+
+			return mapping;
+		}
+
+		private List<BeanPropertyDefinition> getMappedProperties(PersistentEntity<?, ?> entity) {
+
+			List<BeanPropertyDefinition> properties = getBeanDescription(entity.getType()).findProperties();
+			List<BeanPropertyDefinition> withInternalName = new ArrayList<BeanPropertyDefinition>(properties.size());
+
+			for (BeanPropertyDefinition property : properties) {
+
+				AnnotatedMember annotatedMember = findAnnotatedMember(property);
+
+				if (annotatedMember == null || entity.getPersistentProperty(property.getInternalName()) == null) {
+					continue;
+				}
+
+				withInternalName.add(property);
+			}
+
+			return withInternalName;
+		}
+
+		private AnnotatedMember findAnnotatedMember(BeanPropertyDefinition property) {
+
+			if (property.getPrimaryMember() != null) {
+				return property.getPrimaryMember();
+			}
+
+			if (property.getGetter() != null) {
+				return property.getGetter();
+			}
+
+			if (property.getSetter() != null) {
+				return property.getSetter();
+			}
+
+			return null;
+		}
+
+		private static boolean isJsonUnwrapped(AnnotatedMember primaryMember) {
+			return primaryMember.hasAnnotation(JsonUnwrapped.class)
+					&& primaryMember.getAnnotation(JsonUnwrapped.class).enabled();
+		}
+
+		private BeanDescription getBeanDescription(Class<?> type) {
+			return INTROSPECTOR.forDeserialization(mapper.getDeserializationConfig(), mapper.constructType(type),
+					mapper.getDeserializationConfig());
+		}
+	}
+}

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/util/UriUtils.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/util/UriUtils.java
@@ -16,16 +16,19 @@
 package org.springframework.data.rest.webmvc.util;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.hateoas.core.AnnotationMappingDiscoverer;
 import org.springframework.util.Assert;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * Utility methods to work with requests and URIs.
  * 
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 public abstract class UriUtils {
 
@@ -37,8 +40,8 @@ public abstract class UriUtils {
 	 * Returns the value for the mapping variable with the given name.
 	 * 
 	 * @param variable must not be {@literal null} or empty.
-	 * @param parameter
-	 * @param request
+	 * @param method must not be {@literal null}.
+	 * @param lookupPath
 	 * @return
 	 */
 	public static String findMappingVariable(String variable, Method method, String lookupPath) {
@@ -56,5 +59,20 @@ public abstract class UriUtils {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Returns the mapping path segments request mapping.
+	 *
+	 * @param method must not be {@literal null}.
+	 * @return
+	 */
+	public static List<String> getPathSegments(Method method) {
+
+		Assert.notNull(method, "Method must not be null!");
+
+		String mapping = DISCOVERER.getMapping(method.getDeclaringClass(), method);
+
+		return UriComponentsBuilder.fromPath(mapping).build().getPathSegments();
 	}
 }

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/json/MappingAwarePageableArgumentResolverUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/json/MappingAwarePageableArgumentResolverUnitTests.java
@@ -57,7 +57,7 @@ public class MappingAwarePageableArgumentResolverUnitTests {
 	}
 
 	/**
-	 * @see DATAREST-906
+	 * @see DATAREST-906, DATACMNS-918
 	 */
 	@Test
 	public void resolveArgumentShouldReturnTranslatedPageable() throws Exception {
@@ -76,7 +76,7 @@ public class MappingAwarePageableArgumentResolverUnitTests {
 	}
 
 	/**
-	 * @see DATAREST-906
+	 * @see DATAREST-906, DATACMNS-918
 	 */
 	@Test
 	public void resolveArgumentShouldReturnPageableWithoutSort() throws Exception {
@@ -93,7 +93,7 @@ public class MappingAwarePageableArgumentResolverUnitTests {
 	}
 
 	/**
-	 * @see DATAREST-906
+	 * @see DATAREST-906, DATACMNS-918
 	 */
 	@Test
 	public void resolveArgumentShouldReturnNoPageable() throws Exception {

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/json/WrappedPropertiesUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/json/WrappedPropertiesUnitTests.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.rest.webmvc.json;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.data.keyvalue.core.mapping.context.KeyValueMappingContext;
+import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mapping.context.PersistentEntities;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Unit tests for {@link WrappedProperties}.
+ * 
+ * @author Mark Paluch
+ */
+public class WrappedPropertiesUnitTests {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+	private KeyValueMappingContext mappingContext;
+	private PersistentEntities persistentEntities;
+
+	@Before
+	public void setUp() {
+
+		mappingContext = new KeyValueMappingContext();
+		mappingContext.getPersistentEntity(MultiLevelNesting.class);
+		mappingContext.getPersistentEntity(SyntheticProperties.class);
+		persistentEntities = new PersistentEntities(Collections.singleton(mappingContext));
+	}
+
+	/**
+	 * @see DATAREST-910
+	 */
+	@Test
+	public void wrappedPropertiesShouldConsiderSingleLevelUnwrapping() {
+
+		PersistentEntity<?, ?> persistentEntity = persistentEntities.getPersistentEntity(OneLevelNesting.class);
+		WrappedProperties wrappedProperties = WrappedProperties.fromJacksonProperties(persistentEntities, persistentEntity,
+				MAPPER);
+
+		assertThat(wrappedProperties.hasPersistentPropertiesForField("street"), is(true));
+		assertThat(wrappedProperties.hasPersistentPropertiesForField("one"), is(false));
+
+		List<PersistentProperty<?>> street = wrappedProperties.getPersistentProperties("street");
+
+		PersistentProperty<?> addressProperty = persistentEntity.getPersistentProperty("address");
+		PersistentProperty<?> streetProperty = persistentEntities.getPersistentEntity(Address.class)
+				.getPersistentProperty("street");
+
+		assertThat(street, contains(addressProperty, streetProperty));
+	}
+
+	/**
+	 * @see DATAREST-910
+	 */
+	@Test
+	public void wrappedPropertiesShouldConsiderMultiLevelUnwrapping() {
+
+		PersistentEntity<?, ?> persistentEntity = persistentEntities.getPersistentEntity(MultiLevelNesting.class);
+		WrappedProperties wrappedProperties = WrappedProperties.fromJacksonProperties(persistentEntities, persistentEntity,
+				new ObjectMapper());
+
+		assertThat(wrappedProperties.hasPersistentPropertiesForField("pre-one-post"), is(true));
+		assertThat(wrappedProperties.hasPersistentPropertiesForField("pre-street-post"), is(true));
+		assertThat(wrappedProperties.hasPersistentPropertiesForField("nested"), is(false));
+
+		List<PersistentProperty<?>> street = wrappedProperties.getPersistentProperties("pre-street-post");
+
+		PersistentProperty<?> oneLevelNestingProperty = persistentEntity.getPersistentProperty("unwrapped");
+		PersistentProperty<?> addressProperty = persistentEntities.getPersistentEntity(OneLevelNesting.class)
+				.getPersistentProperty("address");
+		PersistentProperty<?> streetProperty = persistentEntities.getPersistentEntity(Address.class)
+				.getPersistentProperty("street");
+
+		assertThat(street, contains(oneLevelNestingProperty, addressProperty, streetProperty));
+	}
+
+	/**
+	 * @see DATAREST-910
+	 */
+	@Test
+	public void wrappedPropertiesShouldConsiderJacksonFieldNames() {
+
+		PersistentEntity<?, ?> persistentEntity = persistentEntities.getPersistentEntity(MultiLevelNesting.class);
+		WrappedProperties wrappedProperties = WrappedProperties.fromJacksonProperties(persistentEntities, persistentEntity,
+				new ObjectMapper());
+
+		assertThat(wrappedProperties.hasPersistentPropertiesForField("pre-zip-post"), is(true));
+	}
+
+	/**
+	 * @see DATAREST-910
+	 */
+	@Test
+	public void wrappedPropertiesShouldIgnoreIgnoredJacksonFields() {
+
+		PersistentEntity<?, ?> persistentEntity = persistentEntities.getPersistentEntity(MultiLevelNesting.class);
+		WrappedProperties wrappedProperties = WrappedProperties.fromJacksonProperties(persistentEntities, persistentEntity,
+				new ObjectMapper());
+
+		assertThat(wrappedProperties.hasPersistentPropertiesForField("pre-street-ignored"), is(false));
+	}
+
+	/**
+	 * @see DATAREST-910
+	 */
+	@Test
+	public void wrappedPropertiesShouldIgnoreSyntheticProperties() {
+
+		PersistentEntity<?, ?> persistentEntity = persistentEntities.getPersistentEntity(SyntheticProperties.class);
+		WrappedProperties wrappedProperties = WrappedProperties.fromJacksonProperties(persistentEntities, persistentEntity,
+				new ObjectMapper());
+
+		assertThat(wrappedProperties.hasPersistentPropertiesForField("street"), is(false));
+	}
+
+	@Data
+	@AllArgsConstructor
+	@NoArgsConstructor
+	static class OneLevelNesting {
+
+		String one;
+		@JsonUnwrapped Address address;
+	}
+
+	static class SyntheticProperties {
+
+		@JsonUnwrapped
+		Address getUnwrapped() {
+			return null;
+		}
+
+		MultiLevelNesting getSynthetic() {
+			return null;
+		}
+
+		@JsonUnwrapped
+		void setWrapped(OneLevelNesting address) {}
+	}
+
+	/**
+	 * <pre>
+	 * <code>
+	  {
+		"multi": "multi",
+		"pre-one-post": "one",
+		"pre-street-post": "street",
+		"pre-zip-post": "zip",
+		"nested": {
+		  "one": "one",
+		  "street": "street",
+		  "zip": "zip"
+		}
+		}
+	  </code>
+	 * </pre>
+	 */
+	@Data
+	@AllArgsConstructor
+	@NoArgsConstructor
+	static class MultiLevelNesting {
+
+		String multi;
+		@JsonUnwrapped(prefix = "pre-", suffix = "-post") OneLevelNesting unwrapped;
+		@JsonIgnore @JsonUnwrapped(prefix = "pre-", suffix = "-ignored") OneLevelNesting ignored;
+		@JsonUnwrapped(enabled = false) OneLevelNesting nested;
+	}
+
+	@Data
+	@AllArgsConstructor
+	@NoArgsConstructor
+	static class Address {
+
+		String street;
+		@JsonProperty("zip") String zipCode;
+	}
+}

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/util/UriUtilsUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/util/UriUtilsUnitTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.rest.webmvc.util;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.junit.Test;
+import org.springframework.util.ClassUtils;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * Unit tests for {@link UriUtils}.
+ * 
+ * @author Mark Paluch
+ */
+public class UriUtilsUnitTests {
+
+	/**
+	 * @see DATAREST-910
+	 */
+	@Test
+	public void pathSegmentsShouldDiscoverPathUsingMethodMapping() throws Exception {
+
+		Method method = ClassUtils.getMethod(MappedMethod.class, "method");
+		List<String> pathSegments = UriUtils.getPathSegments(method);
+
+		assertThat(pathSegments, hasItems("hello", "world"));
+	}
+
+	/**
+	 * @see DATAREST-910
+	 */
+	@Test
+	public void pathSegmentsShouldDiscoverPathUsingTypeAndMethodMapping() throws Exception {
+
+		Method method = ClassUtils.getMethod(MappedClassAndMethod.class, "method");
+		List<String> pathSegments = UriUtils.getPathSegments(method);
+
+		assertThat(pathSegments, hasItems("hello", "world"));
+	}
+
+	static class MappedMethod {
+
+		@RequestMapping("hello/world")
+		public void method() {}
+	}
+
+	@RequestMapping("hello")
+	static class MappedClassAndMethod {
+
+		@RequestMapping("world")
+		public void method() {}
+	}
+}


### PR DESCRIPTION
We now support nested `Sort` properties considering Jackson mapping. `Sort` translation is optional and skipped if the domain class is not resolvable. Translation in the scope of a domain class maps property paths to apply sorting using nested properties.

We also use `SortArgumentResolver` and `PageableArgumentResolver` to resolve and post-process `Sort` and `Pageable` arguments.

A sort string `nested-name` resolves to a property path `anotherWrap.embedded.name`.

``` java
class Aggregate {

    @JsonUnwrapped
    public UnwrapEmbedded anotherWrap;
}

class UnwrapEmbedded {

    @JsonUnwrapped(prefix = "nested-")
    public Embedded embedded;
}

class Embedded {
    public String name;
}
```

---

Related ticket: [DATAREST-910](https://jira.spring.io/browse/DATAREST-910)
Depends on: https://github.com/spring-projects/spring-data-commons/pull/179
