### PR TITLE
DATAREST-976 - Embedded properties are now considered in sort property paths.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-rest-parent</artifactId>
-	<version>2.6.0.BUILD-SNAPSHOT</version>
+	<version>2.6.0.DATAREST-976-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data REST</name>

--- a/spring-data-rest-core/pom.xml
+++ b/spring-data-rest-core/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATAREST-976-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-rest-distribution/pom.xml
+++ b/spring-data-rest-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATAREST-976-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/spring-data-rest-hal-browser/pom.xml
+++ b/spring-data-rest-hal-browser/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATAREST-976-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-data-rest-hal-browser</artifactId>

--- a/spring-data-rest-tests/pom.xml
+++ b/spring-data-rest-tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATAREST-976-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-core/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATAREST-976-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-webmvc</artifactId>
-			<version>2.6.0.BUILD-SNAPSHOT</version>
+			<version>2.6.0.DATAREST-976-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-rest-tests/spring-data-rest-tests-gemfire/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-gemfire/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATAREST-976-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>2.6.0.BUILD-SNAPSHOT</version>
+			<version>2.6.0.DATAREST-976-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATAREST-976-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>2.6.0.BUILD-SNAPSHOT</version>
+			<version>2.6.0.DATAREST-976-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/Book.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/Book.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,15 @@
  */
 package org.springframework.data.rest.webmvc.jpa;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import java.util.HashSet;
 import java.util.Set;
 
 import javax.persistence.CascadeType;
+import javax.persistence.Embeddable;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -45,9 +50,11 @@ public class Book {
 	@RestResource(path = "creators") //
 	public Set<Author> authors;
 
+	public Offer offer;
+
 	protected Book() {}
 
-	public Book(String isbn, String title, long soldUnits, Iterable<Author> authors) {
+	public Book(String isbn, String title, long soldUnits, Iterable<Author> authors, Offer offer) {
 
 		this.isbn = isbn;
 		this.title = title;
@@ -59,5 +66,17 @@ public class Book {
 			author.books.add(this);
 			this.authors.add(author);
 		}
+
+		this.offer = offer;
+	}
+
+	@Getter
+	@Embeddable
+	@AllArgsConstructor
+	@NoArgsConstructor
+	static class Offer {
+
+		double price;
+		String currency;
 	}
 }

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaWebTests.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaWebTests.java
@@ -494,12 +494,12 @@ public class JpaWebTests extends CommonWebTests {
 		assertThat(findBySortedLink.getVariableNames(), hasItems("sort", "projection"));
 
 		// Assert results returned as specified
-		client.follow(findBySortedLink.expand("title,desc")).//
+		client.follow(findBySortedLink.expand("offer.price,desc")).//
 				andExpect(jsonPath("$._embedded.books[0].title").value("Spring Data (Second Edition)")).//
 				andExpect(jsonPath("$._embedded.books[1].title").value("Spring Data")).//
 				andExpect(client.hasLinkWithRel("self"));
 
-		client.follow(findBySortedLink.expand("title,asc")).//
+		client.follow(findBySortedLink.expand("offer.price,asc")).//
 				andExpect(jsonPath("$._embedded.books[0].title").value("Spring Data")).//
 				andExpect(jsonPath("$._embedded.books[1].title").value("Spring Data (Second Edition)")).//
 				andExpect(client.hasLinkWithRel("self"));

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/TestDataPopulator.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/TestDataPopulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.data.rest.webmvc.jpa;
 import java.util.Arrays;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.rest.webmvc.jpa.Book.Offer;
 
 /**
  * @author Jon Brisbin
@@ -54,8 +55,8 @@ public class TestDataPopulator {
 
 		Iterable<Author> authors = this.authors.save(Arrays.asList(ollie, mark, michael, david, john, thomas));
 
-		books.save(new Book("1449323952", "Spring Data", 1000, authors));
-		books.save(new Book("1449323953", "Spring Data (Second Edition)", 2000, authors));
+		books.save(new Book("1449323952", "Spring Data", 1000, authors, new Offer(21.21, "EUR")));
+		books.save(new Book("1449323953", "Spring Data (Second Edition)", 2000, authors, new Offer(30.99, "EUR")));
 	}
 
 	private void populateOrders() {

--- a/spring-data-rest-tests/spring-data-rest-tests-mongodb/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-mongodb/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATAREST-976-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>2.6.0.BUILD-SNAPSHOT</version>
+			<version>2.6.0.DATAREST-976-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-security/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-security/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATAREST-976-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>2.6.0.BUILD-SNAPSHOT</version>
+			<version>2.6.0.DATAREST-976-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-shop/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-shop/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATAREST-976-SNAPSHOT</version>
 	</parent>
 
 	<name>Spring Data REST Tests - Shop</name>

--- a/spring-data-rest-tests/spring-data-rest-tests-solr/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-solr/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATAREST-976-SNAPSHOT</version>
 	</parent>
 
 	<name>Spring Data REST Tests - Solr</name>
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>2.6.0.BUILD-SNAPSHOT</version>
+			<version>2.6.0.DATAREST-976-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-webmvc/pom.xml
+++ b/spring-data-rest-webmvc/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>2.6.0.BUILD-SNAPSHOT</version>
+		<version>2.6.0.DATAREST-976-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
@@ -804,7 +804,8 @@ public class RepositoryRestMvcConfiguration extends HateoasAwareSpringDataWebCon
 		PageableHandlerMethodArgumentResolver pageableResolver = pageableResolver();
 
 		JacksonMappingAwareSortTranslator sortTranslator = new JacksonMappingAwareSortTranslator(objectMapper(),
-				repositories(), DomainClassResolver.of(repositories(), resourceMappings(), baseUri()), persistentEntities());
+				repositories(), DomainClassResolver.of(repositories(), resourceMappings(), baseUri()), persistentEntities(),
+				associationLinks());
 
 		HandlerMethodArgumentResolver sortResolver = new MappingAwareSortArgumentResolver(sortTranslator, sortResolver());
 		HandlerMethodArgumentResolver jacksonPageableResolver = new MappingAwarePageableArgumentResolver(sortTranslator,

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/JacksonMappingAwareSortTranslator.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/JacksonMappingAwareSortTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.context.PersistentEntities;
 import org.springframework.data.repository.support.Repositories;
+import org.springframework.data.rest.webmvc.mapping.Associations;
 import org.springframework.data.rest.webmvc.support.DomainClassResolver;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -62,16 +63,18 @@ public class JacksonMappingAwareSortTranslator {
 	 * @param repositories must not be {@literal null}.
 	 * @param domainClassResolver must not be {@literal null}.
 	 * @param persistentEntities must not be {@literal null}.
+	 * @param associations must not be {@literal null}.
 	 */
 	public JacksonMappingAwareSortTranslator(ObjectMapper objectMapper, Repositories repositories,
-			DomainClassResolver domainClassResolver, PersistentEntities persistentEntities) {
+			DomainClassResolver domainClassResolver, PersistentEntities persistentEntities, Associations associations) {
 
 		Assert.notNull(repositories, "Repositories must not be null!");
 		Assert.notNull(domainClassResolver, "DomainClassResolver must not be null!");
+		Assert.notNull(associations, "Associations must not be null!");
 
 		this.repositories = repositories;
 		this.domainClassResolver = domainClassResolver;
-		this.sortTranslator = new SortTranslator(persistentEntities, objectMapper);
+		this.sortTranslator = new SortTranslator(persistentEntities, objectMapper, associations);
 	}
 
 	/**
@@ -117,6 +120,7 @@ public class JacksonMappingAwareSortTranslator {
 
 		private final @NonNull PersistentEntities persistentEntities;
 		private final @NonNull ObjectMapper objectMapper;
+		private final @NonNull Associations associations;
 
 		/**
 		 * Translates {@link Sort} orders from Jackson-mapped field names to {@link PersistentProperty} names. Properties
@@ -181,7 +185,7 @@ public class JacksonMappingAwareSortTranslator {
 
 				for (PersistentProperty<?> persistentProperty : persistentProperties) {
 
-					if (persistentProperty.isAssociation()) {
+					if (associations.isLinkableAssociation(persistentProperty)) {
 						return Collections.emptyList();
 					}
 

--- a/src/main/asciidoc/paging-and-sorting.adoc
+++ b/src/main/asciidoc/paging-and-sorting.adoc
@@ -127,4 +127,4 @@ To have your results sorted on a particular property, add a `sort` URL parameter
 curl -v "http://localhost:8080/people/search/nameStartsWith?name=K&sort=name,desc"
 ----
 
-To sort the results by more than one property, keep adding as many `sort=PROPERTY` parameters as you need. They will be added to the `Pageable` in the order they appear in the query string.
+To sort the results by more than one property, keep adding as many `sort=PROPERTY` parameters as you need. They will be added to the `Pageable` in the order they appear in the query string. Results can be sorted by top-level and nested properties. Use property path notation to express a nested sort property. Sorting by linkable associations (i.e. resources to top-level resources) is not supported.


### PR DESCRIPTION
We now allow sorting by properties of embedded objects. An embedded object is not linkable to a root object but embedded in the resource itself. If any part of the sort property path points to a linkable association, the whole sort property path is discarded silently and not used for sorting any further.

---

Related ticket: [DATAREST-976](https://jira.spring.io/browse/DATAREST-976)