### PR TITLE
DATAREST-1050 - RepositoryEntityController - PUT method (putItemResou…

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryEntityController.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryEntityController.java
@@ -74,6 +74,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
  * @author Oliver Gierke
  * @author Greg Turnquist
  * @author Jeremy Rickard
+ * @author Marc Easen
  */
 @RepositoryRestController
 class RepositoryEntityController extends AbstractRepositoryRestController implements ApplicationEventPublisherAware {
@@ -363,9 +364,11 @@ class RepositoryEntityController extends AbstractRepositoryRestController implem
 		RepositoryInvoker invoker = resourceInformation.getInvoker();
 		Object objectToSave = payload.getContent();
 		eTag.verify(resourceInformation.getPersistentEntity(), objectToSave);
+		if (payload.isNew()) {
+			throw new ResourceNotFoundException();
+		}
 
-		return payload.isNew() ? createAndReturn(objectToSave, invoker, assembler, config.returnBodyOnCreate(acceptHeader))
-				: saveAndReturn(objectToSave, invoker, PUT, assembler, config.returnBodyOnUpdate(acceptHeader));
+		return saveAndReturn(objectToSave, invoker, PUT, assembler, config.returnBodyOnUpdate(acceptHeader));
 	}
 
 	/**


### PR DESCRIPTION
…rce()) is not idempotent

Within the RepositoryEntityController the  _putItemResource()_ method will check to see if an item exists, if it does not it will proceed to create it. This is not idempotent/safe.

This bug was invoked by using _@RepositoryRestResource_ which uses the _RepositoryEntityController_ behind the scenes.

In the scenario where the entity/resource has a auto generated ID, the putItemResource() is able to create multiple items.

RFC2616 section 9.1.2 (https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html) states: "_Methods can also have the property of "idempotence" in that (aside from error or expiration issues) the side-effects of N > 0 identical requests is the same as for a single request. The methods GET, HEAD, PUT and DELETE share this property. _"

The change in PUT functionality from being update only to create or update can be traced back to "DATAREST-348 - Support for json-patch+json and merge-patch+json media types"

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREST).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
