### PR TITLE
DATAREST-1077: Pass headers from HAL.client on requests

### DIFF
--- a/spring-data-rest-hal-browser/src/main/resources/META-INF/spring-data-rest/hal-browser/js/CustomPostForm.js
+++ b/spring-data-rest-hal-browser/src/main/resources/META-INF/spring-data-rest/hal-browser/js/CustomPostForm.js
@@ -5,7 +5,7 @@
  * NOTE: Because JSON Schema lists all properties, including those that are links, they have to be filtered out.
  * Links have to be set via a PUT operation with the proper media type.
  *
- * @author Greg Turnquist
+ * @author Greg Turnquist, Gregory Frank
  * @since 2.4
  * @see DATAREST-627
  */
@@ -39,7 +39,7 @@ var CustomPostForm = Backbone.View.extend({
 
 		var opts = {
 			url: this.$('.url').val(),
-			headers: {'Content-Type': 'application/json'},
+			headers: _.defaults({'Content-Type': 'application/json'}, HAL.client.getHeaders()),
 			method: this.$('.method').val(),
 			data: this.getNewResourceData()
 		};
@@ -69,6 +69,7 @@ var CustomPostForm = Backbone.View.extend({
 		try {
 			HAL.client.request({
 				method: 'HEAD',
+				headers: HAL.client.getHeaders(),
 				url: this.href
 			}).done(function (message, text, jqXHR) {
 				self.$el.html(self.template({href: self.href}));
@@ -79,7 +80,7 @@ var CustomPostForm = Backbone.View.extend({
 					HAL.client.request({
 						method: 'GET',
 						url: hal._links.profile.href,
-						headers: {'Accept': 'application/schema+json'}
+						headers: _.defaults({'Accept': 'application/schema+json'}, HAL.client.getHeaders())
 					}).done(function (schema) {
 						self.loadJsonEditor(schema);
 					});


### PR DESCRIPTION
Pass headers from HAL.client on requests so custom request headers aren't lost.

E.g. custom Authorization: bearer <token> headers

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREST).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).