### PR TITLE
DATAREST-1105 : Added projection awareness to Associations

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/mapping/Associations.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/mapping/Associations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,23 +21,31 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.rest.core.Path;
+import org.springframework.data.rest.core.config.ProjectionDefinitionConfiguration;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.core.mapping.ResourceMapping;
 import org.springframework.data.rest.core.mapping.ResourceMappings;
 import org.springframework.data.rest.core.mapping.ResourceMetadata;
 import org.springframework.hateoas.Link;
+import org.springframework.hateoas.TemplateVariable;
+import org.springframework.hateoas.TemplateVariables;
+import org.springframework.hateoas.UriTemplate;
 import org.springframework.util.Assert;
+
+import static org.springframework.hateoas.TemplateVariable.VariableType.REQUEST_PARAM;
 
 /**
  * A value object to for {@link Link}s representing associations.
- * 
+ *
  * @author Oliver Gierke
  * @author Greg Turnquist
+ * @author Haroun Pacquee
  * @since 2.1
  */
 @RequiredArgsConstructor
@@ -48,7 +56,7 @@ public class Associations {
 
 	/**
 	 * Returns the links to render for the given {@link Association}.
-	 * 
+	 *
 	 * @param association must not be {@literal null}.
 	 * @param path must not be {@literal null}.
 	 * @return
@@ -65,17 +73,34 @@ public class Associations {
 			ResourceMapping propertyMapping = metadata.getMappingFor(property);
 
 			String href = path.slash(propertyMapping.getPath()).toString();
-			String rel = propertyMapping.getRel();
-
-			return Collections.singletonList(new Link(href, rel));
+			String uri = new UriTemplate(href, getProjectionVariable(property)).toString();
+			return Collections.singletonList(new Link(uri, propertyMapping.getRel()));
 		}
 
 		return Collections.emptyList();
 	}
 
+	private TemplateVariables getProjectionVariable(PersistentProperty<?> property) {
+		ProjectionDefinitionConfiguration projectionConfiguration = config.getProjectionConfiguration();
+		if (isProjectionPresent(property, projectionConfiguration)) {
+			return new TemplateVariables(new TemplateVariable(projectionConfiguration.getParameterName(), REQUEST_PARAM));
+		} else {
+			return TemplateVariables.NONE;
+		}
+	}
+
+	private boolean isProjectionPresent(PersistentProperty<?> property, ProjectionDefinitionConfiguration projectionConfiguration) {
+		return Stream.of(property.getType(),
+						property.getActualType(),
+						property.getRawType(),
+						property.getComponentType(),
+						property.getMapValueType())
+				.anyMatch(projectionConfiguration::hasProjectionFor);
+	}
+
 	/**
 	 * Returns the {@link ResourceMetadata} for the given type.
-	 * 
+	 *
 	 * @param type must not be {@literal null}.
 	 * @return
 	 */
@@ -88,7 +113,7 @@ public class Associations {
 
 	/**
 	 * Returns whether the type of the given {@link PersistentProperty} is configured as lookup type.
-	 * 
+	 *
 	 * @param property must not be {@literal null}.
 	 * @return
 	 */
@@ -105,7 +130,7 @@ public class Associations {
 
 	/**
 	 * Returns whether the given {@link Association} is linkable.
-	 * 
+	 *
 	 * @param association must not be {@literal null}.
 	 * @return
 	 */
@@ -118,7 +143,7 @@ public class Associations {
 
 	/**
 	 * Returns whether the given property is an association that is linkable.
-	 * 
+	 *
 	 * @param property must not be {@literal null}.
 	 * @return
 	 */

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/AssociationLinksUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/AssociationLinksUnitTests.java
@@ -33,6 +33,7 @@ import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.context.PersistentEntities;
 import org.springframework.data.rest.core.Path;
 import org.springframework.data.rest.core.annotation.RestResource;
+import org.springframework.data.rest.core.config.ProjectionDefinitionConfiguration;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.core.mapping.PersistentEntitiesResourceMappings;
 import org.springframework.data.rest.core.mapping.ResourceMappings;
@@ -56,10 +57,11 @@ public class AssociationLinksUnitTests {
 	ResourceMetadata sampleResourceMetadata;
 
 	@Mock RepositoryRestConfiguration config;
+	@Mock ProjectionDefinitionConfiguration projectionDefinitionConfig;
 
 	@Before
 	public void setUp() {
-
+		doReturn(projectionDefinitionConfig).when(config).getProjectionConfiguration();
 		this.mappingContext = new KeyValueMappingContext<>();
 		this.entity = mappingContext.getRequiredPersistentEntity(Sample.class);
 		this.mappings = new PersistentEntitiesResourceMappings(new PersistentEntities(Arrays.asList(mappingContext)));


### PR DESCRIPTION
Association links are created without taking projections into account
This change checks if projections exist for anything related to the
Association and provides the href of the link with the desired
projection template variable.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREST).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
