### PR TITLE
DATAREST-1033 - Fix DomainObjectReader's handling of polymorphic types

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/DomainObjectReader.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/DomainObjectReader.java
@@ -48,8 +48,12 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.DefaultDeserializationContext;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -195,6 +199,76 @@ public class DomainObjectReader {
 	}
 
 	/**
+	 * If the given {@link ObjectNode} indicates that the type of the target has changed, returns an instance of the new
+	 * type. Otherwise, the given target is returned unmodified.
+	 *
+	 * @param root must not be {@literal null}.
+	 * @param target must not be {@literal null}.
+	 * @param mapper must not be {@literal null}.
+	 * @return
+	 * @throws Exception
+	 */
+	<T> T handlePotentialTypeChange(ObjectNode root, T target, ObjectMapper mapper) throws Exception {
+		TypeDeserializer typeDeserializer = mapper.getDeserializationConfig()
+				.findTypeDeserializer(mapper.getTypeFactory().constructType(target.getClass()));
+		if (typeDeserializer == null || typeDeserializer.getPropertyName() == null) {
+			// type did not change
+			return target;
+		}
+		String typePropertyName = typeDeserializer.getPropertyName();
+		if (!root.has(typePropertyName)) {
+			// type did not change
+			return target;
+		}
+		String typePropertyValue = root.get(typePropertyName).asText();
+		JavaType newTargetJavaType = typeDeserializer.getTypeIdResolver()
+				.typeFromId(mapper.getDeserializationContext(), typePropertyValue);
+		if (newTargetJavaType == null || newTargetJavaType.getRawClass().equals(target.getClass())) {
+			// the type property will not be used so remove it to avoid
+			// com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException.UnrecognizedPropertyException
+			root.remove(typePropertyName);
+			// type did not change
+			return target;
+		}
+		// type has changed
+		// serialize the existing target to json
+		ObjectNode existingTargetNode = mapper.valueToTree(target);
+
+		// mapper.getDeserializationContext() doesn't have a DeserializationConfig set on it, so have to create a
+		// new one that does
+		DeserializationContext deserializationContext = new DefaultDeserializationContext.Impl(
+				mapper.getDeserializationContext().getFactory()).createInstance(mapper.getDeserializationConfig(),
+						mapper.getDeserializationContext().getParser(), null);
+		Collection<Object> targetKnownPropertyNames = deserializationContext
+				.findRootValueDeserializer(mapper.getTypeFactory().constructType(target.getClass()))
+				.getKnownPropertyNames();
+		Collection<Object> newTargetKnownPropertyNames = deserializationContext
+				.findRootValueDeserializer(newTargetJavaType).getKnownPropertyNames();
+
+		if (targetKnownPropertyNames != null && newTargetKnownPropertyNames != null) {
+			Iterator<Entry<String, JsonNode>> fieldsIterator = existingTargetNode.fields();
+			while (fieldsIterator.hasNext()) {
+				Entry<String, JsonNode> entry = fieldsIterator.next();
+				// remove the properties that exist in target but not newTarget
+				if (targetKnownPropertyNames.contains(entry.getKey())
+						&& !newTargetKnownPropertyNames.contains(entry.getKey())) {
+					fieldsIterator.remove();
+				}
+			}
+		}
+
+		// apply the root json. This includes the type information.
+		existingTargetNode.setAll(root);
+
+		// the type property will not be used so remove it to avoid
+		// com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException.UnrecognizedPropertyException
+		root.remove(typePropertyName);
+
+		// read the json to create an instance of the new type
+		return mapper.readerFor(newTargetJavaType).readValue(existingTargetNode);
+	}
+
+	/**
 	 * Merges the given {@link ObjectNode} onto the given object.
 	 *
 	 * @param root must not be {@literal null}.
@@ -209,6 +283,8 @@ public class DomainObjectReader {
 		Assert.notNull(root, "Root ObjectNode must not be null!");
 		Assert.notNull(target, "Target object instance must not be null!");
 		Assert.notNull(mapper, "ObjectMapper must not be null!");
+
+		target = handlePotentialTypeChange(root, target, mapper);
 
 		Optional<PersistentEntity<?, ? extends PersistentProperty<?>>> candidate = entities
 				.getPersistentEntity(target.getClass());
@@ -273,12 +349,10 @@ public class DomainObjectReader {
 
 					if (property.isEntity()) {
 						i.remove();
-						execute(() -> doMerge(objectNode, it, mapper));
+						accessor.setProperty(property, execute(() -> doMerge(objectNode, it, mapper)));
 					}
 				}
-
 			});
-
 		}
 
 		return mapper.readerForUpdating(target).readValue(root);


### PR DESCRIPTION
This PR is a rebase of #260 for the master branch instead of the 2.6.x branch.

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREST).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
