### PR TITLE
DATAREST-79 - introduced IllegalStateException on "/" in path segment.

### DIFF
--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/mapping/RepositoryCollectionResourceMapping.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/mapping/RepositoryCollectionResourceMapping.java
@@ -53,10 +53,10 @@ class RepositoryCollectionResourceMapping implements CollectionResourceMapping {
 	/**
 	 * Creates a new {@link RepositoryCollectionResourceMapping} for the given repository using the given
 	 * {@link RelProvider}.
-	 * 
+	 *
+	 * @param metadata must not be {@literal null}.
 	 * @param strategy must not be {@literal null}.
 	 * @param relProvider must not be {@literal null}.
-	 * @param repositoryType must not be {@literal null}.
 	 */
 	RepositoryCollectionResourceMapping(RepositoryMetadata metadata, RepositoryDetectionStrategy strategy,
 			RelProvider relProvider) {
@@ -71,6 +71,13 @@ class RepositoryCollectionResourceMapping implements CollectionResourceMapping {
 		this.annotation = AnnotationUtils.findAnnotation(repositoryType, RestResource.class);
 		this.repositoryAnnotation = AnnotationUtils.findAnnotation(repositoryType, RepositoryRestResource.class);
 		this.repositoryExported = strategy.isExported(metadata);
+
+		if(this.annotation != null) {
+			Assert.doesNotContain(this.annotation.path(), "/", String.format("the 'path' specified in @RestResource at %s must not contain a '/'", metadata.getRepositoryInterface().getName()));
+		}
+		if(this.repositoryAnnotation != null) {
+			Assert.doesNotContain(this.repositoryAnnotation.path(), "/", String.format("the 'path' specified in @RepositoryRestResource at %s must not contain a '/'", metadata.getRepositoryInterface().getName()));
+		}
 
 		Class<?> domainType = metadata.getDomainType();
 		this.domainTypeMapping = EVO_INFLECTOR_IS_PRESENT

--- a/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/mapping/RepositoryCollectionResourceMappingUnitTests.java
+++ b/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/mapping/RepositoryCollectionResourceMappingUnitTests.java
@@ -105,6 +105,16 @@ public class RepositoryCollectionResourceMappingUnitTests {
 		assertThat(mapping.getPath()).isEqualTo(new Path("/objects"));
 	}
 
+	@Test(expected = IllegalArgumentException.class) // DATAREST-79
+	public void throwsExceptionOnInvalidPathSegmentOnRepositoryRestResource(){
+		getResourceMappingFor(RepositoryRestResourceWithInvalidPathSegment.class);
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATAREST-79
+	public void throwsExceptionOnInvalidPathSegmentOnRestResource(){
+		getResourceMappingFor(RestResourceWithInvalidPathSegment.class);
+	}
+
 	private static CollectionResourceMapping getResourceMappingFor(Class<?> repositoryInterface) {
 
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(repositoryInterface);
@@ -132,4 +142,10 @@ public class RepositoryCollectionResourceMappingUnitTests {
 
 	@RepositoryRestResource(collectionResourceRel = "foo", itemResourceRel = "bar")
 	interface RepositoryAnnotatedRepository extends Repository<Person, Long> {}
+
+	@RepositoryRestResource(path = "path/with/slashes")
+	interface RepositoryRestResourceWithInvalidPathSegment extends Repository<Person, Long> {}
+
+	@RestResource(path = "path/with/slashes")
+	interface RestResourceWithInvalidPathSegment extends Repository<Person, Long> {}
 }


### PR DESCRIPTION
"/" is not valid in a path segment and leads to REST endpoints silently failing. It's better to throw an exception when a "/" is encountered in a path segment so the user knows what's going on.
