### PR TITLE
DATAREST-721 - Show input fields for associations in CustomPostForm …

### DIFF
--- a/spring-data-rest-hal-browser/src/main/resources/META-INF/spring-data-rest/hal-browser/js/CustomPostForm.js
+++ b/spring-data-rest-hal-browser/src/main/resources/META-INF/spring-data-rest/hal-browser/js/CustomPostForm.js
@@ -2,13 +2,17 @@
  * Custom Backbone view that uses JSON Schema metadata to create pop-up dialog with actual field names instead of
  * asking user to input raw JSON.
  *
- * NOTE: Because JSON Schema lists all properties, including those that are links, they have to be filtered out.
- * Links have to be set via a PUT operation with the proper media type.
+ * NOTE: Links to other resources are shown as simple text fields. The user is responsible for inserting the correct URI.
+ * For '* to many' associations, it is currently only possible to insert ONE URI.
+ * Additional links have to be set via POST/PUT/PATCH operations with the proper media type.
+ * Jackson has to be configured properly for this to work (set spring.jackson.deserialization.accept-empty-string-as-null-object and
+ * spring.jackson.deserialization.accept-single-value-as-array to true).
  *
  * @author Greg Turnquist
  * @author Gregory Frank
+ * @author Marcel Kauf
  * @since 2.4
- * @see DATAREST-627, DATAREST-1077
+ * @see DATAREST-627, DATAREST-1077, DATAREST-721
  */
 /* jshint strict: true */
 /* globals HAL, Backbone, _, $, window, jqxhr */
@@ -107,16 +111,6 @@ var CustomPostForm = Backbone.View.extend({
 	 */
 	loadJsonEditor: function (schema) {
 		var self = this;
-
-		/**
-		 * Remove URI-based fields since this dialog doesn't handle relationships.
-		 */
-		Object.keys(schema.properties).forEach(function (property) {
-			if (schema.properties[property].hasOwnProperty('format') &&
-				schema.properties[property].format === 'uri') {
-				delete schema.properties[property];
-			}
-		});
 
 		/**
 		 * See https://github.com/jdorn/json-editor#options for more customizing options.


### PR DESCRIPTION
… to be able to create resources with mandatory associations.

Input field for associations are now shown. These are only simple text fields, the user is responsible for inserting the correct URI. It is only possible to enter one URI, additional links have to be added via separate requests, e.g. PATCH. Jackson has to be configured properly for this to work (spring.jackson.deserialization.accept-empty-string-as-null-object,
spring.jackson.deserialization.accept-single-value-as-array). This is just a simple fix but definitely an improvement since it wasn't possible to create resources with mandatory associations before.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREST).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
