### PR TITLE
DATAREST-1143 - throw a ResourceNotFoundException instead of returning an http response with status code directly

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryEntityController.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryEntityController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,6 +74,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
  * @author Oliver Gierke
  * @author Greg Turnquist
  * @author Jeremy Rickard
+ * @author Jeroen Reijn
  */
 @RepositoryRestController
 class RepositoryEntityController extends AbstractRepositoryRestController implements ApplicationEventPublisherAware {
@@ -103,7 +104,6 @@ class RepositoryEntityController extends AbstractRepositoryRestController implem
 	 * @param config must not be {@literal null}.
 	 * @param entityLinks must not be {@literal null}.
 	 * @param assembler must not be {@literal null}.
-	 * @param auditableBeanWrapperFactory must not be {@literal null}.
 	 */
 	@Autowired
 	public RepositoryEntityController(Repositories repositories, RepositoryRestConfiguration config,
@@ -337,7 +337,7 @@ class RepositoryEntityController extends AbstractRepositoryRestController implem
 			return resourceStatus.getStatusAndHeaders(headers, it, entity).toResponseEntity(//
 					() -> assembler.toFullResource(it));
 
-		}).orElseGet(() -> new ResponseEntity<Resource<?>>(HttpStatus.NOT_FOUND));
+		}).orElseThrow(() -> new ResourceNotFoundException());
 	}
 
 	/**

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/RepositoryEntityControllerTest.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/RepositoryEntityControllerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.webmvc;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.keyvalue.core.mapping.KeyValuePersistentEntity;
+import org.springframework.data.keyvalue.core.mapping.context.KeyValueMappingContext;
+import org.springframework.data.mapping.context.PersistentEntities;
+import org.springframework.data.repository.support.Repositories;
+import org.springframework.data.repository.support.RepositoryInvoker;
+import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
+import org.springframework.data.rest.core.mapping.PersistentEntitiesResourceMappings;
+import org.springframework.data.rest.core.mapping.ResourceMappings;
+import org.springframework.data.rest.core.mapping.ResourceMetadata;
+import org.springframework.data.rest.webmvc.support.RepositoryEntityLinks;
+import org.springframework.data.web.PagedResourcesAssembler;
+
+/**
+ * Unit tests for {@link RepositoryEntityController}
+ *
+ * @author Jeroen Reijn
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RepositoryEntityControllerTest {
+
+	@Mock Repositories repositories;
+	@Mock RepositoryRestConfiguration restConfiguration;
+	@Mock RepositoryEntityLinks repositoryEntityLinks;
+	@Mock HttpHeadersPreparer httpHeadersPreparer;
+	@Mock RepositoryInvoker invoker;
+	@Mock PagedResourcesAssembler<Object> assembler;
+
+	KeyValueMappingContext<?, ?> mappingContext = new KeyValueMappingContext<>();
+
+	@Test(expected = ResourceNotFoundException.class) // DATAREST-1143
+	public void testUnknownItemThrowsResourceNotFound() throws Exception {
+
+		KeyValuePersistentEntity<?, ?> entity = mappingContext
+				.getRequiredPersistentEntity(RepositoryPropertyReferenceControllerUnitTests.Sample.class);
+
+		ResourceMappings mappings = new PersistentEntitiesResourceMappings(
+				new PersistentEntities(Collections.singleton(mappingContext)));
+
+		ResourceMetadata metadata = spy(
+				mappings.getMetadataFor(RepositoryPropertyReferenceControllerUnitTests.Sample.class));
+
+		when(metadata.getSupportedHttpMethods())
+				.thenReturn(RepositoryPropertyReferenceControllerUnitTests.AllSupportedHttpMethods.INSTANCE);
+
+		RootResourceInformation information = new RootResourceInformation(metadata, entity, invoker);
+		RepositoryEntityController repositoryEntityController = new RepositoryEntityController(repositories,
+				restConfiguration, repositoryEntityLinks, assembler, httpHeadersPreparer);
+		repositoryEntityController.getItemResource(information, "1", null, null);
+	}
+
+}


### PR DESCRIPTION
Changed getItemResource to throw a ResourceNotFoundException instead of returning an empty ResponseEntity with a status code when an item can't be found. This will allow projects to use a ResponseEntityExceptionHandler and create a custom error message for 404 responses on GET requests, which is not possible at the moment.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREST).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).