### PR TITLE
DATAREST-1096 - Json schema should allow arrays of uris

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/JsonSchema.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/JsonSchema.java
@@ -427,11 +427,14 @@ public class JsonSchema {
 		 * @return
 		 */
 		public JsonSchemaProperty asAssociation() {
-
-			this.items = null;
-			this.uniqueItems = null;
-
-			return withFormat(JsonSchemaFormat.URI);
+			if (this.type.equals("array")) {
+				this.items = new HashMap<>();
+				this.items.put("type", "string");
+				this.items.put("format", "uri");
+				return this;
+			} else {
+				return withFormat(JsonSchemaFormat.URI);
+			}
 		}
 
 		JsonSchemaProperty with(TypeInformation<?> type, String reference) {

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/json/JsonSchemaUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/json/JsonSchemaUnitTests.java
@@ -22,24 +22,41 @@ import org.springframework.data.rest.webmvc.json.JsonSchema.JsonSchemaProperty;
 import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
 
+import java.util.Collection;
+
 /**
  * Unit tests for {@link JsonSchema}.
- * 
+ *
  * @author Oliver Gierke
  */
 public class JsonSchemaUnitTests {
 
-	static final TypeInformation<?> type = ClassTypeInformation.from(Sample.class);
+	private static final TypeInformation<?> typeWithDoubleField = ClassTypeInformation.from(TypeWithDoubleField.class);
+	private static final TypeInformation<?> typeWithAssociations = ClassTypeInformation.from(TypeWithAssociations.class);
 
 	@Test // DATAREST-492
 	public void considersNumberPrimitivesJsonSchemaNumbers() {
 
 		JsonSchemaProperty property = new JsonSchemaProperty("foo", null, "bar", false);
 
-		assertThat(property.with(type.getRequiredProperty("foo")).type).isEqualTo("number");
+		assertThat(property.with(typeWithDoubleField.getRequiredProperty("foo")).type).isEqualTo("number");
 	}
 
-	static class Sample {
-		double foo;
+	@Test // DATAREST-1096
+	public void allowArrayOfUris() {
+		JsonSchemaProperty property = new JsonSchemaProperty("foos", null, null, false);
+
+		final JsonSchemaProperty arrayOfUris = property.with(typeWithAssociations.getRequiredProperty("foos")).asAssociation();
+		assertThat(arrayOfUris.type).isEqualTo("array");
+		assertThat(arrayOfUris.items.get("type")).isEqualTo("string");
+		assertThat(arrayOfUris.items.get("format")).isEqualTo("uri");
+	}
+
+	private static class TypeWithDoubleField {
+		private double foo;
+	}
+
+	private static class TypeWithAssociations {
+		private Collection<TypeWithDoubleField> foos;
 	}
 }


### PR DESCRIPTION
This is a fix for https://jira.spring.io/browse/DATAREST-1096. When having a collection of associations, the JSON schema should be an array of uris IMO. My client needs this information, because a POST request works like

"collectionOfAssociations": ["http://localhost:8080/referencedResources/1", "http://localhost:8080/referencedResources/2"]