### PR TITLE
DATAREST-1176 - Add ability to only expose repository methods explicitly declared for exposure

### DIFF
--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/mapping/RepositoryAwareResourceMetadata.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/mapping/RepositoryAwareResourceMetadata.java
@@ -57,7 +57,7 @@ class RepositoryAwareResourceMetadata implements ResourceMetadata {
 		this.mapping = mapping;
 		this.provider = provider;
 		this.repositoryMetadata = repositoryMetadata;
-		this.crudMethodsSupportedHttpMethods = new CrudMethodsSupportedHttpMethods(repositoryMetadata.getCrudMethods());
+		this.crudMethodsSupportedHttpMethods = new CrudMethodsSupportedHttpMethods(repositoryMetadata.getCrudMethods(), provider);
 	}
 
 	/**

--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/mapping/RepositoryDetectionStrategy.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/mapping/RepositoryDetectionStrategy.java
@@ -96,6 +96,18 @@ public interface RepositoryDetectionStrategy {
 			public boolean isExported(RepositoryMetadata metadata) {
 				return isExplicitlyExported(metadata.getRepositoryInterface(), false);
 			}
+		},
+
+		/**
+		 * Behaves like the annotated strategy on repository level. But it does not export all methods
+		 * of an exported Repository. The methods have to be annotated explicitly too.
+		 */
+		EXPLICIT_METHOD_ANNOTATED {
+
+			@Override
+			public boolean isExported(RepositoryMetadata metadata) {
+				return isExplicitlyExported(metadata.getRepositoryInterface(), false);
+			}
 		};
 
 		/**

--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/mapping/RepositoryMethodResourceMapping.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/mapping/RepositoryMethodResourceMapping.java
@@ -62,7 +62,8 @@ class RepositoryMethodResourceMapping implements MethodResourceMapping {
 	 * @param method must not be {@literal null}.
 	 * @param resourceMapping must not be {@literal null}.
 	 */
-	public RepositoryMethodResourceMapping(Method method, ResourceMapping resourceMapping, RepositoryMetadata metadata) {
+	public RepositoryMethodResourceMapping(Method method, ResourceMapping resourceMapping, RepositoryMetadata metadata,
+										   RepositoryDetectionStrategy strategy) {
 
 		Assert.notNull(method, "Method must not be null!");
 		Assert.notNull(resourceMapping, "ResourceMapping must not be null!");
@@ -70,7 +71,7 @@ class RepositoryMethodResourceMapping implements MethodResourceMapping {
 		RestResource annotation = AnnotationUtils.findAnnotation(method, RestResource.class);
 		String resourceRel = resourceMapping.getRel();
 
-		this.isExported = annotation != null ? annotation.exported() : true;
+		this.isExported = determineIsExported(strategy, annotation);
 		this.rel = annotation == null || !StringUtils.hasText(annotation.rel()) ? method.getName() : annotation.rel();
 		this.path = annotation == null || !StringUtils.hasText(annotation.path()) ? new Path(method.getName())
 				: new Path(annotation.path());
@@ -82,6 +83,14 @@ class RepositoryMethodResourceMapping implements MethodResourceMapping {
 		this.paging = parameterTypes.contains(Pageable.class);
 		this.sorting = parameterTypes.contains(Sort.class);
 		this.metadata = metadata;
+	}
+
+	private boolean determineIsExported(RepositoryDetectionStrategy strategy, RestResource annotation) {
+
+		boolean exportedDefault = strategy
+				!= RepositoryDetectionStrategy.RepositoryDetectionStrategies.EXPLICIT_METHOD_ANNOTATED;
+
+		return annotation != null ? annotation.exported() : exportedDefault;
 	}
 
 	private static final List<ParameterMetadata> discoverParameterMetadata(Method method, String baseRel) {

--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/mapping/RepositoryResourceMappings.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/mapping/RepositoryResourceMappings.java
@@ -40,6 +40,7 @@ import org.springframework.util.Assert;
 public class RepositoryResourceMappings extends PersistentEntitiesResourceMappings {
 
 	private final Repositories repositories;
+	private final RepositoryDetectionStrategy strategy;
 	private final Map<Class<?>, SearchResourceMappings> searchCache = new HashMap<Class<?>, SearchResourceMappings>();
 
 	/**
@@ -73,6 +74,7 @@ public class RepositoryResourceMappings extends PersistentEntitiesResourceMappin
 		Assert.notNull(strategy, "RepositoryDetectionStrategy must not be null!");
 
 		this.repositories = repositories;
+		this.strategy = strategy;
 		this.populateCache(repositories, relProvider, strategy);
 	}
 
@@ -118,7 +120,7 @@ public class RepositoryResourceMappings extends PersistentEntitiesResourceMappin
 		if (resourceMapping.isExported()) {
 			for (Method queryMethod : repositoryInformation.getQueryMethods()) {
 				RepositoryMethodResourceMapping methodMapping = new RepositoryMethodResourceMapping(queryMethod,
-						resourceMapping, repositoryInformation);
+						resourceMapping, repositoryInformation, strategy);
 				if (methodMapping.isExported()) {
 					mappings.add(methodMapping);
 				}
@@ -155,5 +157,9 @@ public class RepositoryResourceMappings extends PersistentEntitiesResourceMappin
 	@Override
 	public boolean isMapped(PersistentProperty<?> property) {
 		return repositories.hasRepositoryFor(property.getActualType()) && super.isMapped(property);
+	}
+
+	public RepositoryDetectionStrategy getRepositoryDetectionStrategy() {
+		return strategy;
 	}
 }

--- a/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/mapping/CrudMethodsSupportedHttpMethodsUnitTests.java
+++ b/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/mapping/CrudMethodsSupportedHttpMethodsUnitTests.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.data.annotation.ReadOnlyProperty;
 import org.springframework.data.annotation.Reference;
@@ -46,6 +47,9 @@ import org.springframework.http.HttpMethod;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class CrudMethodsSupportedHttpMethodsUnitTests {
+
+	@Mock
+	private RepositoryResourceMappings mappings;
 
 	@Test // DATACMNS-589, DATAREST-409
 	public void doesNotSupportAnyHttpMethodForEmptyRepository() {
@@ -118,12 +122,12 @@ public class CrudMethodsSupportedHttpMethodsUnitTests {
 		assertMethodsSupported(getSupportedHttpMethodsFor(NoFindOne.class), ITEM, false, DELETE);
 	}
 
-	private static SupportedHttpMethods getSupportedHttpMethodsFor(Class<?> repositoryInterface) {
+	private SupportedHttpMethods getSupportedHttpMethodsFor(Class<?> repositoryInterface) {
 
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(repositoryInterface);
 		CrudMethods crudMethods = new DefaultCrudMethods(metadata);
 
-		return new CrudMethodsSupportedHttpMethods(crudMethods);
+		return new CrudMethodsSupportedHttpMethods(crudMethods, mappings);
 	}
 
 	private static void assertMethodsSupported(SupportedHttpMethods methods, ResourceType type, boolean supported,

--- a/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/mapping/RepositoryDetectionStrategiesUnitTests.java
+++ b/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/mapping/RepositoryDetectionStrategiesUnitTests.java
@@ -89,6 +89,19 @@ public class RepositoryDetectionStrategiesUnitTests {
 		});
 	}
 
+	@Test // DATAREST-1176
+	public void onlyExplicitAnnotatedMethodsAreExposed() {
+
+		assertExposures(EXPLICIT_METHOD_ANNOTATED, new HashMap<Class<?>, Boolean>() {
+			{
+				put(AnnotatedRepository.class, true);
+				put(HiddenRepository.class, false);
+				put(PublicRepository.class, false);
+				put(PackageProtectedRepository.class, false);
+			}
+		});
+	}
+
 	private static void assertExposures(RepositoryDetectionStrategy strategy, Map<Class<?>, Boolean> expected) {
 
 		for (Entry<Class<?>, Boolean> entry : expected.entrySet()) {

--- a/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/mapping/RepositoryMethodResourceMappingUnitTests.java
+++ b/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/mapping/RepositoryMethodResourceMappingUnitTests.java
@@ -131,7 +131,8 @@ public class RepositoryMethodResourceMappingUnitTests {
 	}
 
 	private RepositoryMethodResourceMapping getMappingFor(Method method) {
-		return new RepositoryMethodResourceMapping(method, resourceMapping, metadata);
+		RepositoryDetectionStrategy strategy = RepositoryDetectionStrategies.DEFAULT;
+		return new RepositoryMethodResourceMapping(method, resourceMapping, metadata, strategy);
 	}
 
 	static class Person {}


### PR DESCRIPTION
The pull request contains a solution to export only explicitly annotated methods via a new detection strategy.
JIRA ticket: https://jira.spring.io/browse/DATAREST-1176