### PR TITLE
DATAREST-1181 - NullPointer during `JsonLateObjectEvaluator.evaluate`

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/patch/JsonLateObjectEvaluator.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/patch/JsonLateObjectEvaluator.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Craig Walls
  * @author Oliver Trosien
  * @author Oliver Gierke
+ * @author Simon Allegraud
  */
 @RequiredArgsConstructor
 class JsonLateObjectEvaluator implements LateObjectEvaluator {
@@ -42,7 +43,7 @@ class JsonLateObjectEvaluator implements LateObjectEvaluator {
 	public Object evaluate(Class<?> type) {
 
 		try {
-			return mapper.readValue(valueNode.traverse(), type);
+			return mapper.readValue(valueNode.traverse(mapper.getFactory().getCodec()), type);
 		} catch (Exception o_O) {
 			throw new PatchException(String.format("Could not read %s into %s!", valueNode, type), o_O);
 		}


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->


- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREST).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

In the `JsonLateObjectEvaluator` class the line `return mapper.readValue(valueNode.traverse(), type);` might throw a NullPointer.

The `traverse()` method instantiate a `TreeTraversingParser` with a null `ObjectCodec`. JacksonModule depending on this ObjectCodec (such as JTS https://github.com/bedatadriven/jackson-datatype-jts) are going to throw a NullPointer.

I'm not really sure how to add test cases since this bug seems to only be triggered with other dependencies. Can I add `jackson-datatype-jts` as a test dependencies ?