### PR TITLE
DATAREST-1232 - Fix AssociationUriResolving with snake case properties

### DIFF
--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/Person.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/Person.java
@@ -58,6 +58,9 @@ public class Person {
 	@ManyToOne //
 	private Person father;
 
+	@ManyToOne //
+	private Person grandFather;
+
 	@Description("Timestamp this person object was created") //
 	private Date created;
 
@@ -123,6 +126,14 @@ public class Person {
 
 	public void setFather(Person father) {
 		this.father = father;
+	}
+
+	public Person getGrandFather() {
+		return grandFather;
+	}
+
+	public void setGrandFather(Person grandFather) {
+		this.grandFather = grandFather;
 	}
 
 	public Date getCreated() {


### PR DESCRIPTION
This pull request fix issue on AssocitationUriResolving when Jackson objectMapper si configured with SNAKE_CASE PropertyNamingStrategy.