### PR TITLE
Content negotiation

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryRestHandlerMapping.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryRestHandlerMapping.java
@@ -201,8 +201,8 @@ public class RepositoryRestHandlerMapping extends BasePathAwareHandlerMapping {
 		}
 
 		HashSet<String> mediaTypes = new LinkedHashSet<String>();
-		mediaTypes.add(configuration.getDefaultMediaType().toString());
-		mediaTypes.add(MediaType.APPLICATION_JSON_VALUE);
+//		mediaTypes.add(configuration.getDefaultMediaType().toString());
+//		mediaTypes.add(MediaType.APPLICATION_JSON_VALUE);
 
 		return new ProducesRequestCondition(mediaTypes.toArray(new String[mediaTypes.size()]));
 	}


### PR DESCRIPTION
Hello,

I'd like to be able to negotiate with the server the content type of the response I'm receiving. At the moment no matter what type of `Accept` header I send, anything different from `application/json` or `application/hal+json` returns 406. I have registered some extra `HttpMessageConverters` in my `RepositoryRestConfigurerAdapter:configureHttpMessageConverters`, but unless I comment the following 2 lines in `RepositoryRestHandlerMapping` it just doesn't work. 

The two lines in `RepositoryRestHandlerMapping` add fallback media types to be `application/json` and `application/hal+json` and the code simply doesn't care of what one has specified in their `Accept ` header. 

Commenting those two lines makes it work fine. I'm not sure what their purpose was or if they are needed. 
