### PR TITLE
repro(patch): test case for adding an item to the end of an array

### DIFF
--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/json/patch/AddOperationUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/json/patch/AddOperationUnitTests.java
@@ -78,6 +78,17 @@ public class AddOperationUnitTests {
 		assertFalse(todos.get(3).isComplete());
 	}
 
+	@Test
+	public void addItemToEndOfArray() {
+
+		List<Todo> todos = new ArrayList<Todo>();
+		todos.add(new Todo(1L, "A", false));
+
+		AddOperation add = AddOperation.of("/1", new Todo(2L, "B", true));
+		add.perform(todos, Todo.class);
+		assertEquals("B", todos.get(1).getDescription());
+	}
+
 	@Test // DATAREST-995
 	public void addsItemsToNestedList() {
 


### PR DESCRIPTION
(Sorry I can't login on Jira ATM, I'll create the ticket there as soon as it's working again)


Currently: adding an item with the index equals to the number of elements in the list throws `org.springframework.expression.spel.SpelEvaluationException: EL1025E: The collection has '1' elements, index '1' is invalid`

For example (in pseudo-code):
```
let object = {foo: ["Hello"]};

let addOperation = {"op": "add", "path": "/foo/1", "value": "world!"};

addOperation.perform(object);
```
is a valid JSON Patch operation but throws with Spring

See the [RFC](https://tools.ietf.org/html/rfc6902):
```
   o  An element to add to an existing array - whereupon the supplied
      value is added to the array at the indicated location.  Any
      elements at or above the specified index are shifted one position
      to the right.  The specified index MUST NOT be greater than the
      number of elements in the array.  If the "-" character is used to
      index the end of the array (see [RFC6901]), this has the effect of
      appending the value to the array.
```

