### PR TITLE
Add supportedMediaTypes to the ProducesRequestCondition

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryRestHandlerMapping.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryRestHandlerMapping.java
@@ -19,11 +19,13 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -41,6 +43,7 @@ import org.springframework.orm.jpa.support.OpenEntityManagerInViewInterceptor;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.MimeType;
 import org.springframework.util.StringUtils;
 import org.springframework.util.StringValueResolver;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -60,6 +63,7 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
  * @author Jon Brisbin
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Petar Tahchiev
  */
 public class RepositoryRestHandlerMapping extends BasePathAwareHandlerMapping {
 
@@ -69,6 +73,7 @@ public class RepositoryRestHandlerMapping extends BasePathAwareHandlerMapping {
 
 	private RepositoryCorsConfigurationAccessor corsConfigurationAccessor;
 	private JpaHelper jpaHelper;
+	private Collection<MediaType> supportedMediaTypes;
 
 	/**
 	 * Creates a new {@link RepositoryRestHandlerMapping} for the given {@link ResourceMappings} and
@@ -203,6 +208,9 @@ public class RepositoryRestHandlerMapping extends BasePathAwareHandlerMapping {
 		HashSet<String> mediaTypes = new LinkedHashSet<String>();
 		mediaTypes.add(configuration.getDefaultMediaType().toString());
 		mediaTypes.add(MediaType.APPLICATION_JSON_VALUE);
+		if (supportedMediaTypes != null) {
+			mediaTypes.addAll(supportedMediaTypes.stream().map(MimeType::toString).collect(Collectors.toList()));
+		}
 
 		return new ProducesRequestCondition(mediaTypes.toArray(new String[mediaTypes.size()]));
 	}
@@ -233,6 +241,10 @@ public class RepositoryRestHandlerMapping extends BasePathAwareHandlerMapping {
 
 		int secondSlashIndex = repositoryLookupPath.indexOf('/', repositoryLookupPath.startsWith("/") ? 1 : 0);
 		return secondSlashIndex == -1 ? repositoryLookupPath : repositoryLookupPath.substring(0, secondSlashIndex);
+	}
+
+	public void setSupportedMediaTypes(Collection<MediaType> supportedMediaTypes) {
+		this.supportedMediaTypes = supportedMediaTypes;
 	}
 
 	/**

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.BeanCreationException;
@@ -173,6 +174,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
  * @author Jon Brisbin
  * @author Greg Turnquist
  * @author Mark Paluch
+ * @author Petar Tahchiev
  */
 @Configuration
 @EnableHypermediaSupport(type = HypermediaType.HAL)
@@ -626,6 +628,7 @@ public class RepositoryRestMvcConfiguration extends HateoasAwareSpringDataWebCon
 		repositoryMapping.setJpaHelper(jpaHelper());
 		repositoryMapping.setApplicationContext(applicationContext);
 		repositoryMapping.setCorsConfigurations(corsConfigurations);
+		repositoryMapping.setSupportedMediaTypes(getSupportedMediaTypes());
 		repositoryMapping.afterPropertiesSet();
 
 		BasePathAwareHandlerMapping basePathMapping = new BasePathAwareHandlerMapping(repositoryRestConfiguration());
@@ -638,6 +641,16 @@ public class RepositoryRestMvcConfiguration extends HateoasAwareSpringDataWebCon
 		mappings.add(repositoryMapping);
 
 		return new DelegatingHandlerMapping(mappings);
+	}
+
+	private Collection<MediaType> getSupportedMediaTypes() {
+
+		List<MediaType> result = new ArrayList<>();
+		for(HttpMessageConverter<?> httpMessageConverter : defaultMessageConverters()) {
+			result.addAll(httpMessageConverter.getSupportedMediaTypes());
+		}
+
+		return result;
 	}
 
 	@Bean


### PR DESCRIPTION
If we don't add the supportedMediaTypes from the registered HttpMessageConverters,
then even through the customer might register another httpMessageConverter they won't be able
to get the response in the desired format.

See DATAREST-1235

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREST).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
