### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -24,4 +24,4 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
 Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
 
-This Code of Conduct is adapted from the http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].
+This Code of Conduct is adapted from the https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
-image:https://spring.io/badges/spring-data-rest/ga.svg[Spring Data REST, link="http://projects.spring.io/spring-data-rest/#quick-start"]
-image:https://spring.io/badges/spring-data-rest/snapshot.svg[Spring Data REST, link="http://projects.spring.io/spring-data-rest/#quick-start"]
+image:https://spring.io/badges/spring-data-rest/ga.svg[Spring Data REST, link="https://projects.spring.io/spring-data-rest/#quick-start"]
+image:https://spring.io/badges/spring-data-rest/snapshot.svg[Spring Data REST, link="https://projects.spring.io/spring-data-rest/#quick-start"]
 
 = Spring Data REST
 
@@ -11,7 +11,7 @@ The first exporter implemented is a JPA Repository exporter. This takes your JPA
 
 Installation instructions are in the docs:
 
-* http://docs.spring.io/spring-data/rest/docs/current/reference/html/[http://docs.spring.io/spring-data/rest/docs/current/reference/html/]
+* https://docs.spring.io/spring-data/rest/docs/current/reference/html/[https://docs.spring.io/spring-data/rest/docs/current/reference/html/]
 
 === License
 
@@ -21,10 +21,10 @@ The Spring Data REST is http://www.apache.org/licenses/LICENSE-2.0.html[Apache 2
 
 Here are some ways for you to get involved in the community:
 
-* Get involved with the Spring community on Stackoverflow. Please help out on the http://stackoverflow.com/questions/tagged/spring-data-rest[spring-data-rest] tag by responding to questions and joining the debate.
+* Get involved with the Spring community on Stackoverflow. Please help out on the https://stackoverflow.com/questions/tagged/spring-data-rest[spring-data-rest] tag by responding to questions and joining the debate.
 * Create https://jira.spring.io/browse/DATAREST[JIRA] tickets for bugs and new features and comment and vote on the ones that you are interested in.
-* Github is for social coding: if you want to write code, we encourage contributions through pull requests from http://help.github.com/forking/[forks of this repository]. If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
-* Watch for upcoming articles on Spring by http://spring.io/blog/[subscribing] to spring.io.
+* Github is for social coding: if you want to write code, we encourage contributions through pull requests from https://help.github.com/forking/[forks of this repository]. If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
+* Watch for upcoming articles on Spring by https://spring.io/blog/[subscribing] to spring.io.
 
 Before we accept a non-trivial patch or pull request we will need you to https://cla.pivotal.io/sign/spring[sign the Contributor License Agreement]. Signing the contributor’s agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do. If you forget to do so, you'll be reminded when you submit a pull request. Active contributors might be asked to join the core team, and given the ability to merge pull requests.
 

--- a/spring-data-rest-hal-browser/src/main/resources/META-INF/spring-data-rest/hal-browser/js/CustomPostForm.js
+++ b/spring-data-rest-hal-browser/src/main/resources/META-INF/spring-data-rest/hal-browser/js/CustomPostForm.js
@@ -168,7 +168,7 @@ var CustomPostForm = Backbone.View.extend({
 	 * }
 	 *
 	 * @param linkHeader - HTTP Response header containing a list of W3C compliant links with rels.
-	 * @see http://www.w3.org/wiki/LinkHeader
+	 * @see https://www.w3.org/wiki/LinkHeader
 	 */
 	w3cLinksToHalLinks: function (linkHeader) {
 		var w3cLinks = linkHeader.split(',');

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/AuthorRepository.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/AuthorRepository.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.CrossOrigin;
  * @author Oliver Gierke
  * @author Mark Paluch
  */
-@CrossOrigin(origins = "http://not.so.far.away", //
+@CrossOrigin(origins = "https://not.so.far.away", //
 		allowCredentials = "true", //
 		methods = { GET, PATCH, POST }, //
 		maxAge = 1234)

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/CorsIntegrationTests.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/CorsIntegrationTests.java
@@ -54,7 +54,7 @@ public class CorsIntegrationTests extends AbstractWebIntegrationTests {
 
 				config.getCorsRegistry().addMapping("/books/**") //
 						.allowedMethods("GET", "PUT", "POST") //
-						.allowedOrigins("http://far.far.away");
+						.allowedOrigins("https://far.far.away");
 			});
 		}
 	}
@@ -65,7 +65,7 @@ public class CorsIntegrationTests extends AbstractWebIntegrationTests {
 		Link findItems = client.discoverUnique(LinkRelation.of("items"));
 
 		// Preflight request
-		mvc.perform(options(findItems.expand().getHref()).header(HttpHeaders.ORIGIN, "http://far.far.away")
+		mvc.perform(options(findItems.expand().getHref()).header(HttpHeaders.ORIGIN, "https://far.far.away")
 				.header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "POST")) //
 				.andExpect(status().isOk()) //
 				.andExpect(
@@ -78,16 +78,16 @@ public class CorsIntegrationTests extends AbstractWebIntegrationTests {
 		Link findBooks = client.discoverUnique(LinkRelation.of("books"));
 
 		// Preflight request
-		mvc.perform(options(findBooks.expand().getHref()).header(HttpHeaders.ORIGIN, "http://far.far.away")
+		mvc.perform(options(findBooks.expand().getHref()).header(HttpHeaders.ORIGIN, "https://far.far.away")
 				.header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "POST")) //
 				.andExpect(status().isOk()) //
-				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://far.far.away")) //
+				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "https://far.far.away")) //
 				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "GET,PUT,POST"));
 
 		// CORS request
-		mvc.perform(get(findBooks.expand().getHref()).header(HttpHeaders.ORIGIN, "http://far.far.away")) //
+		mvc.perform(get(findBooks.expand().getHref()).header(HttpHeaders.ORIGIN, "https://far.far.away")) //
 				.andExpect(status().isOk()) //
-				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://far.far.away"));
+				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "https://far.far.away"));
 	}
 
 	/**
@@ -98,20 +98,20 @@ public class CorsIntegrationTests extends AbstractWebIntegrationTests {
 
 		// Preflight request
 		mvc.perform(options("/books/xml/1234") //
-				.header(HttpHeaders.ORIGIN, "http://far.far.away") //
+				.header(HttpHeaders.ORIGIN, "https://far.far.away") //
 				.header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET")) //
 				.andExpect(status().isOk()) //
 				.andExpect(header().longValue(HttpHeaders.ACCESS_CONTROL_MAX_AGE, 77123)) //
-				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://far.far.away")) //
+				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "https://far.far.away")) //
 				// See https://jira.spring.io/browse/SPR-14792
 				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, containsString("GET,PUT,POST")));
 
 		// CORS request
 		mvc.perform(get("/books/xml/1234") //
-				.header(HttpHeaders.ORIGIN, "http://far.far.away") //
+				.header(HttpHeaders.ORIGIN, "https://far.far.away") //
 				.accept(MediaType.APPLICATION_XML)) //
 				.andExpect(status().isOk()) //
-				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://far.far.away"));
+				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "https://far.far.away"));
 	}
 
 	/**
@@ -121,11 +121,11 @@ public class CorsIntegrationTests extends AbstractWebIntegrationTests {
 	public void appliesCorsConfigurationOnCustomControllerMethod() throws Exception {
 
 		// Preflight request
-		mvc.perform(options("/books/pdf/1234").header(HttpHeaders.ORIGIN, "http://far.far.away")
+		mvc.perform(options("/books/pdf/1234").header(HttpHeaders.ORIGIN, "https://far.far.away")
 				.header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET")) //
 				.andExpect(status().isOk()) //
 				.andExpect(header().longValue(HttpHeaders.ACCESS_CONTROL_MAX_AGE, 4711)) //
-				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://far.far.away")) //
+				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "https://far.far.away")) //
 				// See https://jira.spring.io/browse/SPR-14792
 				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, containsString("GET,PUT,POST")));
 	}
@@ -136,11 +136,11 @@ public class CorsIntegrationTests extends AbstractWebIntegrationTests {
 		Link authorsLink = client.discoverUnique(LinkRelation.of("authors"));
 
 		// Preflight request
-		mvc.perform(options(authorsLink.expand().getHref()).header(HttpHeaders.ORIGIN, "http://not.so.far.away")
+		mvc.perform(options(authorsLink.expand().getHref()).header(HttpHeaders.ORIGIN, "https://not.so.far.away")
 				.header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "POST")) //
 				.andExpect(status().isOk()) //
 				.andExpect(header().longValue(HttpHeaders.ACCESS_CONTROL_MAX_AGE, 1234)) //
-				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://not.so.far.away")) //
+				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "https://not.so.far.away")) //
 				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true")) //
 				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "GET,PATCH,POST"));
 	}
@@ -149,11 +149,11 @@ public class CorsIntegrationTests extends AbstractWebIntegrationTests {
 	public void appliesCorsConfigurationOnRepositoryToCustomControllers() throws Exception {
 
 		// Preflight request
-		mvc.perform(options("/authors/pdf/1234").header(HttpHeaders.ORIGIN, "http://not.so.far.away")
+		mvc.perform(options("/authors/pdf/1234").header(HttpHeaders.ORIGIN, "https://not.so.far.away")
 				.header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET")) //
 				.andExpect(status().isOk()) //
 				.andExpect(header().longValue(HttpHeaders.ACCESS_CONTROL_MAX_AGE, 1234)) //
-				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://not.so.far.away")) //
+				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "https://not.so.far.away")) //
 				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true")) //
 				.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "GET,PATCH,POST"));
 	}

--- a/spring-data-rest-tests/spring-data-rest-tests-mongodb/src/test/java/org/springframework/data/rest/webmvc/support/RepositoryLinkBuildUnitTests.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-mongodb/src/test/java/org/springframework/data/rest/webmvc/support/RepositoryLinkBuildUnitTests.java
@@ -48,7 +48,7 @@ public class RepositoryLinkBuildUnitTests {
 
 	@Test // DATAREST-292, DATAREST-296
 	public void usesBaseUriOnlyIfItIsAbsolute() {
-		assertRootUriFor("http://foobar/api", "http://foobar/api/profile");
+		assertRootUriFor("https://foobar/api", "https://foobar/api/profile");
 	}
 
 	private void assertRootUriFor(String baseUri, String expectedUri) {

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositorySchemaController.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositorySchemaController.java
@@ -32,7 +32,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
  * @author Jon Brisbin
  * @author Oliver Gierke
  * @author Greg Turnquist
- * @see <a href="http://json-schema.org/">http://json-schema.org/</a>
+ * @see <a href="https://json-schema.org/">https://json-schema.org/</a>
  */
 @BasePathAwareController
 class RepositorySchemaController {

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/JsonPatchHandler.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/JsonPatchHandler.java
@@ -37,9 +37,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  *
  * @author Oliver Gierke
  * @author Mathias Düsterhöft
- * @see <a href="http://tools.ietf.org/html/rfc6902">http://tools.ietf.org/html/rfc6902</a>
+ * @see <a href="https://tools.ietf.org/html/rfc6902">https://tools.ietf.org/html/rfc6902</a>
  * @see <a href=
- *      "http://tools.ietf.org/html/draft-ietf-appsawg-json-merge-patch-02">http://tools.ietf.org/html/draft-ietf-appsawg-json-merge-patch-02</a>
+ *      "https://tools.ietf.org/html/draft-ietf-appsawg-json-merge-patch-02">https://tools.ietf.org/html/draft-ietf-appsawg-json-merge-patch-02</a>
  */
 class JsonPatchHandler {
 

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/JsonSchema.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/JsonSchema.java
@@ -82,7 +82,7 @@ public class JsonSchema {
 
 	@JsonProperty("$schema")
 	public String getSchema() {
-		return "http://json-schema.org/draft-04/schema#";
+		return "https://json-schema.org/draft-04/schema#";
 	}
 
 	public String getType() {
@@ -113,7 +113,7 @@ public class JsonSchema {
 	 * @param typeInformation
 	 * @return
 	 * @see <a href=
-	 *      "http://json-schema.org/latest/json-schema-core.html#anchor8">http://json-schema.org/latest/json-schema-core.html#anchor8</a>
+	 *      "https://json-schema.org/latest/json-schema-core.html#anchor8">https://json-schema.org/latest/json-schema-core.html#anchor8</a>
 	 */
 	private static String toJsonSchemaType(TypeInformation<?> typeInformation) {
 

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/RepositoryCorsConfigurationAccessorUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/RepositoryCorsConfigurationAccessorUnitTests.java
@@ -80,7 +80,7 @@ public class RepositoryCorsConfigurationAccessorUnitTests {
 		assertThat(configuration.getAllowCredentials()).isTrue();
 		assertThat(configuration.getAllowedHeaders()).contains("Content-type");
 		assertThat(configuration.getExposedHeaders()).contains("Accept");
-		assertThat(configuration.getAllowedOrigins()).contains("http://far.far.away");
+		assertThat(configuration.getAllowedOrigins()).contains("https://far.far.away");
 		assertThat(configuration.getAllowedMethods()).contains("PATCH");
 		assertThat(configuration.getAllowedMethods()).doesNotContain("DELETE");
 		assertThat(configuration.getAllowCredentials()).isTrue();
@@ -102,7 +102,7 @@ public class RepositoryCorsConfigurationAccessorUnitTests {
 	@CrossOrigin
 	interface AnnotatedRepository {}
 
-	@CrossOrigin(origins = "http://far.far.away", //
+	@CrossOrigin(origins = "https://far.far.away", //
 			allowedHeaders = "Content-type", //
 			maxAge = 1234, exposedHeaders = "Accept", //
 			methods = RequestMethod.PATCH, //

--- a/spring-data-rest-webmvc/src/test/resources/cassandra.yaml
+++ b/spring-data-rest-webmvc/src/test/resources/cassandra.yaml
@@ -1,7 +1,7 @@
 # Cassandra storage config YAML
 
 # NOTE:
-#   See http://wiki.apache.org/cassandra/StorageConfiguration for
+#   See https://wiki.apache.org/cassandra/StorageConfiguration for
 #   full explanations of configuration directives
 # /NOTE
 
@@ -12,7 +12,7 @@ cluster_name: 'Test Cluster'
 # You should always specify InitialToken when setting up a production
 # cluster for the first time, and often when adding capacity later.
 # The principle is that each node should be given an equal slice of
-# the token ring; see http://wiki.apache.org/cassandra/Operations
+# the token ring; see https://wiki.apache.org/cassandra/Operations
 # for more details.
 #
 # If blank, Cassandra will request a token bisecting the range of
@@ -21,7 +21,7 @@ cluster_name: 'Test Cluster'
 # a random token, which will lead to hot spots.
 #initial_token:
 
-# See http://wiki.apache.org/cassandra/HintedHandoff
+# See https://wiki.apache.org/cassandra/HintedHandoff
 hinted_handoff_enabled: true
 # this defines the maximum amount of time a dead host will have hints
 # generated.  After it has been dead this long, new hints for it will not be
@@ -88,7 +88,7 @@ permissions_validity_in_ms: 2000
 # - CollatingOPP collates according to EN,US rules rather than lexical byte
 #   ordering.  Use this as an example if you need custom collation.
 #
-# See http://wiki.apache.org/cassandra/Operations for more on
+# See https://wiki.apache.org/cassandra/Operations for more on
 # partitioners and token selection.
 partitioner: org.apache.cassandra.dht.Murmur3Partitioner
 
@@ -571,7 +571,7 @@ index_interval: 128
 #
 # The passwords used in these options must match the passwords used when generating
 # the keystore and truststore.  For instructions on generating these files, see:
-# http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
+# https://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
 #
 encryption_options:
     internode_encryption: none

--- a/src/main/asciidoc/configuring-cors.adoc
+++ b/src/main/asciidoc/configuring-cors.adoc
@@ -3,7 +3,7 @@
 
 For security reasons, browsers prohibit AJAX calls to resources residing outside the current origin. When working with client-side HTTP requests issued by a browser, you want to enable specific HTTP resources to be accessible.
 
-Spring Data REST, as of 2.6, supports http://en.wikipedia.org/wiki/Cross-origin_resource_sharing[Cross-Origin Resource Sharing] (CORS) through http://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/web.html#mvc-cors[Spring's CORS] support.
+Spring Data REST, as of 2.6, supports https://en.wikipedia.org/wiki/Cross-origin_resource_sharing[Cross-Origin Resource Sharing] (CORS) through https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/web.html#mvc-cors[Spring's CORS] support.
 
 
 == Repository Interface CORS Configuration
@@ -23,7 +23,7 @@ In the preceding example, CORS support is enabled for the whole `PersonRepositor
 ====
 [source, java]
 ----
-@CrossOrigin(origins = "http://domain2.com",
+@CrossOrigin(origins = "https://domain2.com",
   methods = { RequestMethod.GET, RequestMethod.POST, RequestMethod.DELETE },
   maxAge = 3600)
 interface PersonRepository extends CrudRepository<Person, Long> {}
@@ -34,7 +34,7 @@ The preceding example enables CORS support for the whole `PersonRepository` by p
 
 == Repository REST Controller Method CORS Configuration
 
-Spring Data REST fully supports http://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/web.html#controller-method-cors-configuration[Spring Web MVC's controller method configuration] on custom REST controllers that share repository base paths, as the following example shows:
+Spring Data REST fully supports https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/web.html#controller-method-cors-configuration[Spring Web MVC's controller method configuration] on custom REST controllers that share repository base paths, as the following example shows:
 
 ====
 [source, java]
@@ -71,7 +71,7 @@ public class SpringDataRestCustomization extends RepositoryRestConfigurerAdapter
   public void configureRepositoryRestConfiguration(RepositoryRestConfiguration config) {
 
     config.getCorsRegistry().addMapping("/person/**")
-      .allowedOrigins("http://domain2.com")
+      .allowedOrigins("https://domain2.com")
       .allowedMethods("PUT", "DELETE")
       .allowedHeaders("header1", "header2", "header3")
       .exposedHeaders("header1", "header2")

--- a/src/main/asciidoc/custom-jackson-deserialization.adoc
+++ b/src/main/asciidoc/custom-jackson-deserialization.adoc
@@ -21,7 +21,7 @@ public class MyEntity {
 ----
 ====
 
-In a default configuration, Jackson has no idea what class to instantiate when POSTing new data to the exporter. You need to tell Jackson either through an annotation or, more cleanly, by registering a type mapping by using a http://wiki.fasterxml.com/JacksonFeatureModules[Module].
+In a default configuration, Jackson has no idea what class to instantiate when POSTing new data to the exporter. You need to tell Jackson either through an annotation or, more cleanly, by registering a type mapping by using a https://wiki.fasterxml.com/JacksonFeatureModules[Module].
 
 Any `Module` bean declared within the scope of your `ApplicationContext` is picked up by the exporter and registered with its `ObjectMapper`. To add this special abstract class type mapping, you can create a `Module` bean and, in the `setupModule` method, add an appropriate `TypeResolver`, as follows:
 
@@ -44,7 +44,7 @@ public class MyCustomModule extends SimpleModule {
 ----
 ====
 
-Once you have access to the `SetupContext` object in your `Module`, you can do all sorts of cool things to configure Jackon's JSON mapping. You can read more about how http://wiki.fasterxml.com/JacksonFeatureModules[Modules work on Jackson's wiki].
+Once you have access to the `SetupContext` object in your `Module`, you can do all sorts of cool things to configure Jackon's JSON mapping. You can read more about how https://wiki.fasterxml.com/JacksonFeatureModules[Modules work on Jackson's wiki].
 
 == Adding Custom Serializers for Domain Types
 

--- a/src/main/asciidoc/etags-and-other-conditionals.adoc
+++ b/src/main/asciidoc/etags-and-other-conditionals.adoc
@@ -7,7 +7,7 @@ This section shows how Spring Data REST uses standard HTTP headers to enhance pe
 [[conditional.etag]]
 == `ETag`, `If-Match`, and `If-None-Match` Headers
 
-The http://tools.ietf.org/html/rfc7232#section-2.3[`ETag` header] provides a way to tag resources. This can prevent clients from overriding each other while also making it possible to reduce unnecessary calls.
+The https://tools.ietf.org/html/rfc7232#section-2.3[`ETag` header] provides a way to tag resources. This can prevent clients from overriding each other while also making it possible to reduce unnecessary calls.
 
 Consider the following example:
 
@@ -35,7 +35,7 @@ Only if the resource's current `ETag` state matches the `If-Match` header is the
 
 WARNING: The term, "`version,`" may carry different semantics with different data stores and even different semantics within your application. Spring Data REST effectively delegates to the data store's metamodel to discern if a field is versioned and, if so, only allows the listed updates if `ETag` elements match.
 
-The http://tools.ietf.org/html/rfc7232#section-3.2[`If-None-Match` header] provides an alternative. Instead of conditional updates, `If-None-Match` allows conditional queries. Consider the following example:
+The https://tools.ietf.org/html/rfc7232#section-3.2[`If-None-Match` header] provides an alternative. Instead of conditional updates, `If-None-Match` allows conditional queries. Consider the following example:
 
 ====
 ----
@@ -50,7 +50,7 @@ NOTE: This POJO is from an `ETag`-based unit test, so it does not have `@Entity`
 [[conditional.if-modified-since]]
 == `If-Modified-Since` header
 
-The http://tools.ietf.org/html/rfc7232#section-3.3[`If-Modified-Since` header] provides a way to check whether a resource has been updated since the last request, which lets applications avoid resending the same data. Consider the following example:
+The https://tools.ietf.org/html/rfc7232#section-3.3[`If-Modified-Since` header] provides a way to check whether a resource has been updated since the last request, which lets applications avoid resending the same data. Consider the following example:
 
 .The last modification date captured in a domain type
 ====

--- a/src/main/asciidoc/events.adoc
+++ b/src/main/asciidoc/events.adoc
@@ -84,4 +84,4 @@ public class RepositoryConfiguration {
 ----
 ====
 
-NOTE: Spring Data REST events are customized http://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/core.html#context-functionality-events[Spring application events]. By default, Spring events are synchronous, unless they get republished across a boundary (such as issuing a WebSocket event or crossing into a thread).
+NOTE: Spring Data REST events are customized https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/core.html#context-functionality-events[Spring application events]. By default, Spring events are synchronous, unless they get republished across a boundary (such as issuing a WebSocket event or crossing into a thread).

--- a/src/main/asciidoc/getting-started.adoc
+++ b/src/main/asciidoc/getting-started.adoc
@@ -37,7 +37,7 @@ The following example shows how to use Maven to include Spring Data Rest in a Sp
 ----
 ====
 
-NOTE: You need not supply the version number if you use the http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#build-tool-plugins-gradle-plugin[Spring Boot Gradle plugin] or the http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#build-tool-plugins-maven-plugin[Spring Boot Maven plugin].
+NOTE: You need not supply the version number if you use the https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#build-tool-plugins-gradle-plugin[Spring Boot Gradle plugin] or the https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#build-tool-plugins-maven-plugin[Spring Boot Maven plugin].
 
 When you use Spring Boot, Spring Data REST gets configured automatically.
 
@@ -82,7 +82,7 @@ IMPORTANT: This step is unnecessary if you use Spring Boot's auto-configuration.
 
 To customize the configuration, register a `RepositoryRestConfigurer` (or extend `RepositoryRestConfigurerAdapter`) and implement or override the `configure…`-methods relevant to your use case.
 
-Make sure you also configure Spring Data repositories for the store you use. For details on that, see the reference documentation for the http://projects.spring.io/spring-data/[corresponding Spring Data module].
+Make sure you also configure Spring Data repositories for the store you use. For details on that, see the reference documentation for the https://projects.spring.io/spring-data/[corresponding Spring Data module].
 
 [[getting-started.basic-settings]]
 == Basic Settings for Spring Data REST
@@ -190,11 +190,11 @@ At this point, you must also configure your key data store.
 
 Spring Data REST officially supports:
 
-* http://projects.spring.io/spring-data-jpa/[Spring Data JPA]
-* http://projects.spring.io/spring-data-mongodb/[Spring Data MongoDB]
-* http://projects.spring.io/spring-data-neo4j/[Spring Data Neo4j]
-* http://projects.spring.io/spring-data-gemfire/[Spring Data GemFire]
-* http://projects.spring.io/spring-data-cassandra/[Spring Data Cassandra]
+* https://projects.spring.io/spring-data-jpa/[Spring Data JPA]
+* https://projects.spring.io/spring-data-mongodb/[Spring Data MongoDB]
+* https://projects.spring.io/spring-data-neo4j/[Spring Data Neo4j]
+* https://projects.spring.io/spring-data-gemfire/[Spring Data GemFire]
+* https://projects.spring.io/spring-data-cassandra/[Spring Data Cassandra]
 
 The following Getting Started guides can help you get up and running quickly:
 

--- a/src/main/asciidoc/integration.adoc
+++ b/src/main/asciidoc/integration.adoc
@@ -9,8 +9,8 @@ This section details various ways to integrate with Spring Data REST components,
 Sometimes you need to add links to exported resources in your own custom-built Spring MVC controllers. There are three basic levels of linking available:
 
 * Manually assembling links.
-* Using Spring HATEOAS's http://docs.spring.io/spring-hateoas/docs/current/reference/html/#fundamentals.obtaining-links.builder[`LinkBuilder`] with `linkTo()`, `slash()`, and so on.
-* Using Spring Data REST's implementation of http://docs.spring.io/spring-data/rest/docs/current/api/org/springframework/data/rest/webmvc/support/RepositoryEntityLinks.html[`RepositoryEntityLinks`].
+* Using Spring HATEOAS's https://docs.spring.io/spring-hateoas/docs/current/reference/html/#fundamentals.obtaining-links.builder[`LinkBuilder`] with `linkTo()`, `slash()`, and so on.
+* Using Spring Data REST's implementation of https://docs.spring.io/spring-data/rest/docs/current/api/org/springframework/data/rest/webmvc/support/RepositoryEntityLinks.html[`RepositoryEntityLinks`].
 
 The first suggestion is terrible and should be avoided at all costs. It makes your code brittle and high-risk. The second is handy when creating links to other hand-written Spring MVC controllers. The last one, which we explore in the rest of this section, is good for looking up resource links that are exported by Spring Data REST.
 
@@ -54,4 +54,4 @@ With the class in the preceding example, you can use the following operations:
 
 |===
 
-NOTE: All of the search-based links support extra parameters for paging and sorting. See http://docs.spring.io/spring-data/rest/docs/current/api/org/springframework/data/rest/webmvc/support/RepositoryEntityLinks.html[`RepositoryEntityLinks`] for the details. There is also `linkFor(Class<?> type)`, but that returns a Spring HATEOAS `LinkBuilder`, which returns you to the lower level API. Try to use the other ones first.
+NOTE: All of the search-based links support extra parameters for paging and sorting. See https://docs.spring.io/spring-data/rest/docs/current/api/org/springframework/data/rest/webmvc/support/RepositoryEntityLinks.html[`RepositoryEntityLinks`] for the details. There is also `linkFor(Class<?> type)`, but that returns a Spring HATEOAS `LinkBuilder`, which returns you to the lower level API. Try to use the other ones first.

--- a/src/main/asciidoc/metadata.adoc
+++ b/src/main/asciidoc/metadata.adoc
@@ -6,7 +6,7 @@ This section details the various forms of metadata provided by a Spring Data RES
 [[metadata.alps]]
 == Application-Level Profile Semantics (ALPS)
 
-[quote, M. Admundsen / L. Richardson / M. Foster, http://tools.ietf.org/html/draft-amundsen-richardson-foster-alps-00]
+[quote, M. Admundsen / L. Richardson / M. Foster, https://tools.ietf.org/html/draft-amundsen-richardson-foster-alps-00]
 http://alps.io/[ALPS] is a data format for defining simple descriptions of application-level semantics, similar in complexity to HTML microformats.  An ALPS document can be used as a profile to explain the application semantics of a document with an application-agnostic media type (such as HTML, HAL, Collection+JSON, Siren, etc.). This increases the reusability of profile documents across media types.
 
 Spring Data REST provides an ALPS document for every exported repository. It contains information about both the RESTful transitions
@@ -35,7 +35,7 @@ document would be as follows:
 ====
 
 A profile link, as defined in https://tools.ietf.org/html/rfc6906[RFC 6906], is a place to include application-level details. The
-http://tools.ietf.org/html/draft-amundsen-richardson-foster-alps-00[ALPS draft spec] is meant to define a particular profile format,
+https://tools.ietf.org/html/draft-amundsen-richardson-foster-alps-00[ALPS draft spec] is meant to define a particular profile format,
 which we explore later in this section.
 
 If you navigate into the profile link at `localhost:8080/profile`, you see content resembling the following:
@@ -152,7 +152,7 @@ You can also find a `profile` link in the collection of `_links` when you examin
 <2> It has a *profile* link to the same URI for metadata.
 ====
 
-Again, by default, the `profile` link serves up ALPS. However, if you use an http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1[`Accept` header], it can serve `application/alps+json`.
+Again, by default, the `profile` link serves up ALPS. However, if you use an https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1[`Accept` header], it can serve `application/alps+json`.
 
 [[metadata.alps.control-types]]
 === Hypermedia Control Types
@@ -313,7 +313,7 @@ properties files with different messages.
 [[metadata.json-schema]]
 == JSON Schema
 
-http://json-schema.org/[JSON Schema] is another form of metadata supported by Spring Data REST. Per their website, JSON Schema has the following advantages:
+https://json-schema.org/[JSON Schema] is another form of metadata supported by Spring Data REST. Per their website, JSON Schema has the following advantages:
 
 * Describes your existing data format
 * Clear, human- and machine-readable documentation
@@ -384,7 +384,7 @@ In this case, if you executed `curl -H 'Accept:application/schema+json' http://l
   },
   "descriptors" : { },
   "type" : "object",
-  "$schema" : "http://json-schema.org/draft-04/schema#"
+  "$schema" : "https://json-schema.org/draft-04/schema#"
 }
 ----
 
@@ -417,7 +417,7 @@ You can also find a `profile` link in the collection of `_links` when you examin
 <2> It has a *profile* link to the same URI for metadata.
 ====
 
-Again, the `profile` link serves <<metadata.alps,ALPS>> by default. If you supply it with an http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1[`Accept` header] of `application/schema+json`, it renders the JSON Schema representation.
+Again, the `profile` link serves <<metadata.alps,ALPS>> by default. If you supply it with an https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1[`Accept` header] of `application/schema+json`, it renders the JSON Schema representation.
 
 //= JSON Patch
 

--- a/src/main/asciidoc/paging-and-sorting.adoc
+++ b/src/main/asciidoc/paging-and-sorting.adoc
@@ -32,7 +32,7 @@ The Spring Data REST exporter recognizes the returned `Page` and gives you the r
 [[paging-and-sorting.prev-and-next-links]]
 === Previous and Next Links
 
-Each paged response returns links to the previous and next pages of results based on the current page by using the IANA-defined link relations http://www.w3.org/TR/html5/links.html#link-type-prev[`prev`] and http://www.w3.org/TR/html5/links.html#link-type-next[`next`]. If you are currently at the first page of results, however, no `prev` link is rendered. For the last page of results, no `next` link is rendered.
+Each paged response returns links to the previous and next pages of results based on the current page by using the IANA-defined link relations https://www.w3.org/TR/html5/links.html#link-type-prev[`prev`] and https://www.w3.org/TR/html5/links.html#link-type-next[`next`]. If you are currently at the first page of results, however, no `prev` link is rendered. For the last page of results, no `next` link is rendered.
 
 Consider the following example, where we set the page size to 5:
 

--- a/src/main/asciidoc/preface.adoc
+++ b/src/main/asciidoc/preface.adoc
@@ -7,7 +7,7 @@
 
 * Version control: https://github.com/spring-projects/spring-data-rest
 * Bugtracker: https://jira.spring.io/browse/DATAREST
-* Project page: http://projects.spring.io/spring-data-rest
+* Project page: https://projects.spring.io/spring-data-rest
 * Release repository: https://repo.spring.io/libs-release
 * Milestone repository: https://repo.spring.io/libs-milestone
 * Snapshot repository: https://repo.spring.io/libs-snapshot

--- a/src/main/asciidoc/projections-excerpts.adoc
+++ b/src/main/asciidoc/projections-excerpts.adoc
@@ -295,7 +295,7 @@ interface PersonRepository extends CrudRepository<Person, Long> {}
 
 The preceding example directs Spring Data REST to use the `NoAddresses` projection when embedding `Person` resources into collections or related resources.
 
-NOTE: Excerpt projections are not automatically applied to single resources. They have to be applied deliberately. Excerpt projections are meant to provide a default preview of collection data but not when fetching individual resources. See http://stackoverflow.com/questions/30220333/why-is-an-excerpt-projection-not-applied-automatically-for-a-spring-data-rest-it[Why is an excerpt projection not applied automatically for a Spring Data REST item resource?] for a discussion on the subject.
+NOTE: Excerpt projections are not automatically applied to single resources. They have to be applied deliberately. Excerpt projections are meant to provide a default preview of collection data but not when fetching individual resources. See https://stackoverflow.com/questions/30220333/why-is-an-excerpt-projection-not-applied-automatically-for-a-spring-data-rest-it[Why is an excerpt projection not applied automatically for a Spring Data REST item resource?] for a discussion on the subject.
 
 In addition to altering the default rendering, excerpts have additional rendering options as shown in the next section.
 

--- a/src/main/asciidoc/repository-resources.adoc
+++ b/src/main/asciidoc/repository-resources.adoc
@@ -42,7 +42,7 @@ If the configuration values (`RepositoryRestConfiguration.returnBodyOnUpdate` an
 [[repository-resources.resource-discoverability]]
 === Resource Discoverability
 
-A core principle of https://spring.io/understanding/HATEOAS[HATEOAS] is that resources should be discoverable through the publication of links that point to the available resources. There are a few competing de-facto standards of how to represent links in JSON. By default, Spring Data REST uses http://tools.ietf.org/html/draft-kelly-json-hal[HAL] to render responses. HAL defines the links to be contained in a property of the returned document.
+A core principle of https://spring.io/understanding/HATEOAS[HATEOAS] is that resources should be discoverable through the publication of links that point to the available resources. There are a few competing de-facto standards of how to represent links in JSON. By default, Spring Data REST uses https://tools.ietf.org/html/draft-kelly-json-hal[HAL] to render responses. HAL defines the links to be contained in a property of the returned document.
 
 Resource discovery starts at the top level of the application. By issuing a request to the root URL under which the Spring Data REST application is deployed, the client can extract, from the returned JSON object, a set of links that represent the next level of resources that are available to the client.
 

--- a/src/main/asciidoc/representations.adoc
+++ b/src/main/asciidoc/representations.adoc
@@ -48,7 +48,7 @@ protected void configureJacksonObjectMapper(ObjectMapper objectMapper) {
 ----
 ====
 
-Once you have access to the `SetupContext` object in your `Module`, you can do all sorts of cool things to configure Jackson's JSON mapping. You can read more about how `Module` instances work on http://wiki.fasterxml.com/JacksonFeatureModules[Jackson's wiki].
+Once you have access to the `SetupContext` object in your `Module`, you can do all sorts of cool things to configure Jackson's JSON mapping. You can read more about how `Module` instances work on https://wiki.fasterxml.com/JacksonFeatureModules[Jackson's wiki].
 
 === Adding Custom Serializers for Domain Types
 

--- a/src/main/asciidoc/security.adoc
+++ b/src/main/asciidoc/security.adoc
@@ -1,7 +1,7 @@
 [[security]]
 = Security
 :spring-data-rest-root: ../../../..
-:spring-security-docs: http://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle
+:spring-security-docs: https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle
 
 Spring Data REST works quite well with Spring Security. This section shows examples of how to secure your Spring Data REST services with method-level security.
 

--- a/src/main/asciidoc/spring-data-rest-examples.adoc
+++ b/src/main/asciidoc/spring-data-rest-examples.adoc
@@ -19,7 +19,7 @@ https://github.com/spring-projects/spring-data-examples/tree/master/rest/project
 [[spring-data-examples.spring-security]]
 == Spring Data REST with Spring Security
 
-https://github.com/spring-projects/spring-data-examples/tree/master/rest/security[This example] shows how to secure a http://projects.spring.io/spring-data-rest[Spring Data REST] application in multiple ways with http://projects.spring.io/spring-security[Spring Security].
+https://github.com/spring-projects/spring-data-examples/tree/master/rest/security[This example] shows how to secure a https://projects.spring.io/spring-data-rest[Spring Data REST] application in multiple ways with https://projects.spring.io/spring-security[Spring Security].
 
 [[spring-data-examples.starbucks]]
 == Starbucks example

--- a/src/main/resources/license.txt
+++ b/src/main/resources/license.txt
@@ -244,13 +244,13 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
 
-Copyright (c) 1999-2009, OW2 Consortium <http://www.ow2.org/>
+Copyright (c) 1999-2009, OW2 Consortium <https://www.ow2.org/>
 
 
 >>> CGLIB 3.0 (cglib:cglib:3.0):
 
 Per the LICENSE file in the CGLIB JAR distribution downloaded from
-http://sourceforge.net/projects/cglib/files/cglib3/3.0/cglib-3.0.jar/download,
+https://sourceforge.net/projects/cglib/files/cglib3/3.0/cglib-3.0.jar/download,
 CGLIB 3.0 is licensed under the Apache License, version 2.0, the text of which
 is included above.
 
@@ -262,7 +262,7 @@ other similar licenses that require the source code and/or modifications to
 source code to be made available (as would be noted above), you may obtain a
 copy of the source code corresponding to the binaries for such open source
 components and modifications thereto, if any, (the "Source Files"), by
-downloading the Source Files from http://www.springsource.org/download, or by
+downloading the Source Files from https://www.springsource.org/download, or by
 sending a request, with your name and address to:
 
     VMware, Inc., 3401 Hillview Avenue


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://alps.io (200) with 2 occurrences could not be migrated:  
   ([https](https://alps.io) result AnnotatedConnectException).
* [ ] http://alps.io/ (200) with 1 occurrences could not be migrated:  
   ([https](https://alps.io/) result AnnotatedConnectException).
* [ ] http://stateless.co/hal_specification.html (200) with 2 occurrences could not be migrated:  
   ([https](https://stateless.co/hal_specification.html) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://tools.ietf.org/html/draft-amundsen-richardson-foster-alps-00 (301) with 2 occurrences migrated to:  
  https://tools.ietf.org/html/draft-amundsen-richardson-foster-alps-00 ([https](https://tools.ietf.org/html/draft-amundsen-richardson-foster-alps-00) result ReadTimeoutException).
* [ ] http://tools.ietf.org/html/draft-ietf-appsawg-json-merge-patch-02 (301) with 2 occurrences migrated to:  
  https://tools.ietf.org/html/draft-ietf-appsawg-json-merge-patch-02 ([https](https://tools.ietf.org/html/draft-ietf-appsawg-json-merge-patch-02) result ReadTimeoutException).
* [ ] http://tools.ietf.org/html/draft-kelly-json-hal (301) with 1 occurrences migrated to:  
  https://tools.ietf.org/html/draft-kelly-json-hal ([https](https://tools.ietf.org/html/draft-kelly-json-hal) result ReadTimeoutException).
* [ ] http://tools.ietf.org/html/rfc6902 (301) with 2 occurrences migrated to:  
  https://tools.ietf.org/html/rfc6902 ([https](https://tools.ietf.org/html/rfc6902) result ReadTimeoutException).
* [ ] http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html (ReadTimeoutException) with 2 occurrences migrated to:  
  https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html ([https](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html) result SSLException).
* [ ] http://www.w3.org/TR/html5/links.html (ReadTimeoutException) with 2 occurrences migrated to:  
  https://www.w3.org/TR/html5/links.html ([https](https://www.w3.org/TR/html5/links.html) result SSLException).
* [ ] http://www.w3.org/wiki/LinkHeader (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/wiki/LinkHeader ([https](https://www.w3.org/wiki/LinkHeader) result SSLException).
* [ ] http://domain2.com (UnknownHostException) with 2 occurrences migrated to:  
  https://domain2.com ([https](https://domain2.com) result UnknownHostException).
* [ ] http://far.far.away (UnknownHostException) with 14 occurrences migrated to:  
  https://far.far.away ([https](https://far.far.away) result UnknownHostException).
* [ ] http://foobar/api (UnknownHostException) with 1 occurrences migrated to:  
  https://foobar/api ([https](https://foobar/api) result UnknownHostException).
* [ ] http://foobar/api/profile (UnknownHostException) with 1 occurrences migrated to:  
  https://foobar/api/profile ([https](https://foobar/api/profile) result UnknownHostException).
* [ ] http://not.so.far.away (UnknownHostException) with 5 occurrences migrated to:  
  https://not.so.far.away ([https](https://not.so.far.away) result UnknownHostException).
* [ ] http://wiki.fasterxml.com/JacksonFeatureModules (UnknownHostException) with 3 occurrences migrated to:  
  https://wiki.fasterxml.com/JacksonFeatureModules ([https](https://wiki.fasterxml.com/JacksonFeatureModules) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring/docs/ with 3 occurrences migrated to:  
  https://docs.spring.io/spring/docs/ ([https](https://docs.spring.io/spring/docs/) result 200).
* [ ] http://en.wikipedia.org/wiki/Cross-origin_resource_sharing with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Cross-origin_resource_sharing ([https](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) result 200).
* [ ] http://json-schema.org/ with 3 occurrences migrated to:  
  https://json-schema.org/ ([https](https://json-schema.org/) result 200).
* [ ] http://json-schema.org/draft-04/schema with 2 occurrences migrated to:  
  https://json-schema.org/draft-04/schema ([https](https://json-schema.org/draft-04/schema) result 200).
* [ ] http://json-schema.org/latest/json-schema-core.html with 2 occurrences migrated to:  
  https://json-schema.org/latest/json-schema-core.html ([https](https://json-schema.org/latest/json-schema-core.html) result 200).
* [ ] http://projects.spring.io/spring-data-cassandra/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-cassandra/ ([https](https://projects.spring.io/spring-data-cassandra/) result 200).
* [ ] http://projects.spring.io/spring-data-gemfire/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-gemfire/ ([https](https://projects.spring.io/spring-data-gemfire/) result 200).
* [ ] http://projects.spring.io/spring-data-jpa/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-jpa/ ([https](https://projects.spring.io/spring-data-jpa/) result 200).
* [ ] http://projects.spring.io/spring-data-mongodb/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-mongodb/ ([https](https://projects.spring.io/spring-data-mongodb/) result 200).
* [ ] http://projects.spring.io/spring-data-neo4j/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-neo4j/ ([https](https://projects.spring.io/spring-data-neo4j/) result 200).
* [ ] http://projects.spring.io/spring-data-rest/ with 2 occurrences migrated to:  
  https://projects.spring.io/spring-data-rest/ ([https](https://projects.spring.io/spring-data-rest/) result 200).
* [ ] http://projects.spring.io/spring-data/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data/ ([https](https://projects.spring.io/spring-data/) result 200).
* [ ] http://spring.io/blog/ with 1 occurrences migrated to:  
  https://spring.io/blog/ ([https](https://spring.io/blog/) result 200).
* [ ] http://stackoverflow.com/questions/30220333/why-is-an-excerpt-projection-not-applied-automatically-for-a-spring-data-rest-it with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/30220333/why-is-an-excerpt-projection-not-applied-automatically-for-a-spring-data-rest-it ([https](https://stackoverflow.com/questions/30220333/why-is-an-excerpt-projection-not-applied-automatically-for-a-spring-data-rest-it) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-data-rest with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-data-rest ([https](https://stackoverflow.com/questions/tagged/spring-data-rest) result 200).
* [ ] http://tools.ietf.org/html/rfc7232 with 3 occurrences migrated to:  
  https://tools.ietf.org/html/rfc7232 ([https](https://tools.ietf.org/html/rfc7232) result 200).
* [ ] http://wiki.apache.org/cassandra/HintedHandoff with 1 occurrences migrated to:  
  https://wiki.apache.org/cassandra/HintedHandoff ([https](https://wiki.apache.org/cassandra/HintedHandoff) result 200).
* [ ] http://wiki.apache.org/cassandra/Operations with 2 occurrences migrated to:  
  https://wiki.apache.org/cassandra/Operations ([https](https://wiki.apache.org/cassandra/Operations) result 200).
* [ ] http://wiki.apache.org/cassandra/StorageConfiguration with 1 occurrences migrated to:  
  https://wiki.apache.org/cassandra/StorageConfiguration ([https](https://wiki.apache.org/cassandra/StorageConfiguration) result 200).
* [ ] http://www.ow2.org/ with 1 occurrences migrated to:  
  https://www.ow2.org/ ([https](https://www.ow2.org/) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.spring.io/spring-data/rest/docs/current/api/org/springframework/data/rest/webmvc/support/RepositoryEntityLinks.html with 2 occurrences migrated to:  
  https://docs.spring.io/spring-data/rest/docs/current/api/org/springframework/data/rest/webmvc/support/RepositoryEntityLinks.html ([https](https://docs.spring.io/spring-data/rest/docs/current/api/org/springframework/data/rest/webmvc/support/RepositoryEntityLinks.html) result 301).
* [ ] http://docs.spring.io/spring-data/rest/docs/current/reference/html/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-data/rest/docs/current/reference/html/ ([https](https://docs.spring.io/spring-data/rest/docs/current/reference/html/) result 301).
* [ ] http://docs.spring.io/spring-hateoas/docs/current/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-hateoas/docs/current/reference/html/ ([https](https://docs.spring.io/spring-hateoas/docs/current/reference/html/) result 301).
* [ ] http://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle ([https](https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle) result 301).
* [ ] http://help.github.com/forking/ with 1 occurrences migrated to:  
  https://help.github.com/forking/ ([https](https://help.github.com/forking/) result 301).
* [ ] http://projects.spring.io/spring-data-rest with 2 occurrences migrated to:  
  https://projects.spring.io/spring-data-rest ([https](https://projects.spring.io/spring-data-rest) result 301).
* [ ] http://projects.spring.io/spring-security with 1 occurrences migrated to:  
  https://projects.spring.io/spring-security ([https](https://projects.spring.io/spring-security) result 301).
* [ ] http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html with 1 occurrences migrated to:  
  https://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html ([https](https://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html) result 302).
* [ ] http://sourceforge.net/projects/cglib/files/cglib3/3.0/cglib-3.0.jar/download with 1 occurrences migrated to:  
  https://sourceforge.net/projects/cglib/files/cglib3/3.0/cglib-3.0.jar/download ([https](https://sourceforge.net/projects/cglib/files/cglib3/3.0/cglib-3.0.jar/download) result 302).
* [ ] http://www.springsource.org/download with 1 occurrences migrated to:  
  https://www.springsource.org/download ([https](https://www.springsource.org/download) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 4 occurrences
* http://localhost/api/profile with 1 occurrences
* http://localhost/people/4 with 1 occurrences
* http://localhost/people/4/father with 1 occurrences
* http://localhost/people/4/siblings with 1 occurrences
* http://localhost:8080 with 1 occurrences
* http://localhost:8080/ with 3 occurrences
* http://localhost:8080/addresses with 1 occurrences
* http://localhost:8080/api/alps with 1 occurrences
* http://localhost:8080/foo/ with 2 occurrences
* http://localhost:8080/orders with 1 occurrences
* http://localhost:8080/people with 3 occurrences
* http://localhost:8080/people/ with 1 occurrences
* http://localhost:8080/people/?size=5 with 1 occurrences
* http://localhost:8080/people/search/nameStartsWith?name=K&sort=name,desc with 1 occurrences
* http://localhost:8080/people/search/names with 2 occurrences
* http://localhost:8080/persons with 7 occurrences
* http://localhost:8080/persons/ with 1 occurrences
* http://localhost:8080/persons/1 with 5 occurrences
* http://localhost:8080/persons/1/address with 3 occurrences
* http://localhost:8080/persons/1?projection=noAddresses with 1 occurrences
* http://localhost:8080/persons/search with 1 occurrences
* http://localhost:8080/persons/search/findByName with 2 occurrences
* http://localhost:8080/persons/search/names with 1 occurrences
* http://localhost:8080/persons?page=0&size=5 with 1 occurrences
* http://localhost:8080/persons?page=1&size=5 with 2 occurrences
* http://localhost:8080/persons?page=2&size=5 with 1 occurrences
* http://localhost:8080/profile with 3 occurrences
* http://localhost:8080/profile/addresses with 4 occurrences
* http://localhost:8080/profile/persons with 7 occurrences