### PR TITLE
DATAREST-1356 - Fix for a bug around single link PUTs introduced in 554d6cb2

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryPropertyReferenceController.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryPropertyReferenceController.java
@@ -77,6 +77,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
  * @author Jon Brisbin
  * @author Oliver Gierke
  * @author Greg Turnquist
+ * @author Brandon Vulaj
  */
 @RepositoryRestController
 @SuppressWarnings({ "unchecked" })

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryPropertyReferenceController.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryPropertyReferenceController.java
@@ -318,7 +318,7 @@ class RepositoryPropertyReferenceController extends AbstractRepositoryRestContro
 									"Cannot PATCH a reference to this singular property since the property type is not a List or a Map.");
 				}
 
-				if (source.getLinks().hasSingleLink()) {
+				if (!source.getLinks().hasSingleLink()) {
 					throw new IllegalArgumentException(
 							"Must send only 1 link to update a property reference that isn't a List or a Map.");
 				}


### PR DESCRIPTION
Fix for the change:
```diff
-				if (source.getLinks().size() != 1) {
+				if (source.getLinks().hasSingleLink()) {
```

https://github.com/spring-projects/spring-data-rest/commit/554d6cb27b84cebedc651a5a25b10ccfb0cf8265#diff-1d7c16fe1992fef13a47fa8ab8599718L317