### PR TITLE
DATAREST-1397 - Adapt to CORS changes in AbstractHandlerMapping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-rest-parent</artifactId>
-	<version>3.2.0.BUILD-SNAPSHOT</version>
+	<version>3.2.0.DATAREST-1397-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data REST</name>

--- a/spring-data-rest-core/pom.xml
+++ b/spring-data-rest-core/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>3.2.0.BUILD-SNAPSHOT</version>
+		<version>3.2.0.DATAREST-1397-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-rest-distribution/pom.xml
+++ b/spring-data-rest-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>3.2.0.BUILD-SNAPSHOT</version>
+		<version>3.2.0.DATAREST-1397-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-rest-hal-browser/pom.xml
+++ b/spring-data-rest-hal-browser/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>3.2.0.BUILD-SNAPSHOT</version>
+		<version>3.2.0.DATAREST-1397-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-data-rest-hal-browser</artifactId>

--- a/spring-data-rest-hal-explorer/pom.xml
+++ b/spring-data-rest-hal-explorer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>3.2.0.BUILD-SNAPSHOT</version>
+		<version>3.2.0.DATAREST-1397-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-data-rest-hal-explorer</artifactId>

--- a/spring-data-rest-tests/pom.xml
+++ b/spring-data-rest-tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>3.2.0.BUILD-SNAPSHOT</version>
+		<version>3.2.0.DATAREST-1397-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-core/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.2.0.BUILD-SNAPSHOT</version>
+		<version>3.2.0.DATAREST-1397-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-webmvc</artifactId>
-			<version>3.2.0.BUILD-SNAPSHOT</version>
+			<version>3.2.0.DATAREST-1397-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-rest-tests/spring-data-rest-tests-gemfire/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-gemfire/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.2.0.BUILD-SNAPSHOT</version>
+		<version>3.2.0.DATAREST-1397-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>3.2.0.BUILD-SNAPSHOT</version>
+			<version>3.2.0.DATAREST-1397-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.2.0.BUILD-SNAPSHOT</version>
+		<version>3.2.0.DATAREST-1397-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>3.2.0.BUILD-SNAPSHOT</version>
+			<version>3.2.0.DATAREST-1397-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/CorsIntegrationTests.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/CorsIntegrationTests.java
@@ -37,7 +37,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 /**
- * Web integration tests specific to Cross-origin resource sharing.
+ * Web integration tests specific to Cross-origin resource sharing applying global CORS config defaults mixed with local
+ * controller/repository declarations.
  *
  * @author Mark Paluch
  * @soundtrack 2 Unlimited - No Limit

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/LocalConfigCorsIntegrationTests.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/LocalConfigCorsIntegrationTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.webmvc.jpa;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.rest.tests.AbstractWebIntegrationTests;
+import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.LinkRelation;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Web integration tests specific to Cross-origin resource sharing using repository interface CORS configuration.
+ *
+ * @author Mark Paluch
+ * @soundtrack RFLKTD - Liquid Crystals
+ */
+@ContextConfiguration
+public class LocalConfigCorsIntegrationTests extends AbstractWebIntegrationTests {
+
+	static class CorsConfig extends JpaRepositoryConfig {
+
+		@Bean
+		RepositoryRestConfigurer repositoryRestConfigurer() {
+			return RepositoryRestConfigurer.withConfig(c -> {});
+		}
+	}
+
+	/**
+	 * @see ItemRepository
+	 */
+	@Test // DATAREST-1397
+	public void appliesRepositoryCorsConfiguration() throws Exception {
+
+		Link findItems = client.discoverUnique(LinkRelation.of("items"));
+
+		// Preflight request
+		mvc.perform(options(findItems.expand().getHref()).header(HttpHeaders.ORIGIN, "http://far.far.example")
+				.header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "POST")) //
+				.andExpect(status().isOk()) //
+				.andExpect(
+						header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS,TRACE"));
+	}
+}

--- a/spring-data-rest-tests/spring-data-rest-tests-mongodb/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-mongodb/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.2.0.BUILD-SNAPSHOT</version>
+		<version>3.2.0.DATAREST-1397-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>3.2.0.BUILD-SNAPSHOT</version>
+			<version>3.2.0.DATAREST-1397-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-security/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-security/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.2.0.BUILD-SNAPSHOT</version>
+		<version>3.2.0.DATAREST-1397-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>3.2.0.BUILD-SNAPSHOT</version>
+			<version>3.2.0.DATAREST-1397-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-shop/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-shop/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.2.0.BUILD-SNAPSHOT</version>
+		<version>3.2.0.DATAREST-1397-SNAPSHOT</version>
 	</parent>
 
 	<name>Spring Data REST Tests - Shop</name>

--- a/spring-data-rest-tests/spring-data-rest-tests-solr/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-solr/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.2.0.BUILD-SNAPSHOT</version>
+		<version>3.2.0.DATAREST-1397-SNAPSHOT</version>
 	</parent>
 
 	<name>Spring Data REST Tests - Solr</name>
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>3.2.0.BUILD-SNAPSHOT</version>
+			<version>3.2.0.DATAREST-1397-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-webmvc/pom.xml
+++ b/spring-data-rest-webmvc/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>3.2.0.BUILD-SNAPSHOT</version>
+		<version>3.2.0.DATAREST-1397-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/BasePathAwareHandlerMapping.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/BasePathAwareHandlerMapping.java
@@ -114,6 +114,15 @@ public class BasePathAwareHandlerMapping extends RequestMappingHandlerMapping {
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.web.servlet.handler.AbstractHandlerMapping#hasCorsConfigurationSource(java.lang.Object)
+	 */
+	@Override
+	protected boolean hasCorsConfigurationSource(Object handler) {
+		return true;
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping#getMappingForMethod(java.lang.reflect.Method, java.lang.Class)
 	 */
 	@Override

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryRestHandlerMapping.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryRestHandlerMapping.java
@@ -192,6 +192,15 @@ public class RepositoryRestHandlerMapping extends BasePathAwareHandlerMapping {
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.web.servlet.handler.AbstractHandlerMapping#hasCorsConfigurationSource(java.lang.Object)
+	 */
+	@Override
+	protected boolean hasCorsConfigurationSource(Object handler) {
+		return true;
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.web.servlet.handler.AbstractHandlerMapping#extendInterceptors(java.util.List)
 	 */
 	@Override


### PR DESCRIPTION
We now enable CORS handling for all requests by overriding the newly introduced `hasCorsConfigurationSource` method. We cannot detect CORS configuration handling solely on the handler but require path headers to resolve repository interface mappings.

---

Related ticket: [DATAREST-1397](https://jira.spring.io/browse/DATAREST-1397).