### PR TITLE
DATAREST-1096 - Json schema should allow arrays of uris

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/JsonSchema.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/JsonSchema.java
@@ -46,6 +46,7 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
  *
  * @author Jon Brisbin
  * @author Oliver Gierke
+ * @author Christoph Huber
  */
 @JsonInclude(Include.NON_EMPTY)
 public class JsonSchema {
@@ -427,11 +428,14 @@ public class JsonSchema {
 		 * @return
 		 */
 		public JsonSchemaProperty asAssociation() {
-
-			this.items = null;
-			this.uniqueItems = null;
-
-			return withFormat(JsonSchemaFormat.URI);
+			if (this.type.equals("array")) {
+				this.items = new HashMap<>();
+				this.items.put("type", "string");
+				this.items.put("format", "uri");
+				return this;
+			} else {
+				return withFormat(JsonSchemaFormat.URI);
+			}
 		}
 
 		JsonSchemaProperty with(TypeInformation<?> type, String reference) {

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/json/JsonSchemaUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/json/JsonSchemaUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 original author or authors.
+ * Copyright 2015-2019 original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,24 +22,42 @@ import org.springframework.data.rest.webmvc.json.JsonSchema.JsonSchemaProperty;
 import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
 
+import java.util.Collection;
+
 /**
  * Unit tests for {@link JsonSchema}.
  *
  * @author Oliver Gierke
+ * @author Christoph Huber
  */
 public class JsonSchemaUnitTests {
 
-	static final TypeInformation<?> type = ClassTypeInformation.from(Sample.class);
+	private static final TypeInformation<?> typeWithDoubleField = ClassTypeInformation.from(TypeWithDoubleField.class);
+	private static final TypeInformation<?> typeWithAssociations = ClassTypeInformation.from(TypeWithAssociations.class);
 
 	@Test // DATAREST-492
 	public void considersNumberPrimitivesJsonSchemaNumbers() {
 
 		JsonSchemaProperty property = new JsonSchemaProperty("foo", null, "bar", false);
 
-		assertThat(property.with(type.getRequiredProperty("foo")).type).isEqualTo("number");
+		assertThat(property.with(typeWithDoubleField.getRequiredProperty("foo")).type).isEqualTo("number");
 	}
 
-	static class Sample {
-		double foo;
+	@Test // DATAREST-1096
+	public void allowArrayOfUris() {
+		JsonSchemaProperty property = new JsonSchemaProperty("foos", null, null, false);
+
+		final JsonSchemaProperty arrayOfUris = property.with(typeWithAssociations.getRequiredProperty("foos")).asAssociation();
+		assertThat(arrayOfUris.type).isEqualTo("array");
+		assertThat(arrayOfUris.items.get("type")).isEqualTo("string");
+		assertThat(arrayOfUris.items.get("format")).isEqualTo("uri");
+	}
+
+	private static class TypeWithDoubleField {
+		private double foo;
+	}
+
+	private static class TypeWithAssociations {
+		private Collection<TypeWithDoubleField> foos;
 	}
 }


### PR DESCRIPTION
I closed my old pull request for this issue by mistake. So I created a new one that is based on the current master branch and checklist below. Please let me know if I need to improve something.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREST).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
