### PR TITLE
DATAREST-1407 - Updated example for customizing resource URLs.

### DIFF
--- a/src/main/asciidoc/customizing-sdr.adoc
+++ b/src/main/asciidoc/customizing-sdr.adoc
@@ -19,13 +19,14 @@ On Java 8, we can register the mapping methods as method references to tweak the
 [source, java]
 ----
 @Component
-public class SpringDataRestCustomization extends RepositoryRestConfigurerAdapter {
+public class SpringDataRestCustomization extends RepositoryRestConfigurer {
 
   @Override
   public void configureRepositoryRestConfiguration(RepositoryRestConfiguration config) {
-
-    config.withCustomEntityLookup().//
-      forRepository(UserRepository.class, User::getUsername, UserRepository::findByUsername);
+    config.withEntityLookup()
+      .forRepository(UserRepository.class)
+      .withIdMapping(User::getUsername)
+      .withLookup(UserRepository::findByUsername); 
   }
 }
 ----


### PR DESCRIPTION
Removed the reference to the deprecated RepositoryRestConfigurerAdapter, and updated the entity-lookup/ID translation example to use the currently supported API.
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREST).
- **N/A** You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- **N/A** You submit test cases (unit or integration tests) that back your changes.
- **N/A** You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Obvious fix (in my personal opinion, at least).