### PR TITLE
Only log server errors as error

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryRestExceptionHandler.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryRestExceptionHandler.java
@@ -165,7 +165,11 @@ public class RepositoryRestExceptionHandler {
 		if (exception != null) {
 
 			String message = exception.getMessage();
-			LOG.error(message, exception);
+			if (status.is5xxServerError()) {
+				LOG.error(message, exception);
+			} else {
+				LOG.debug(message, exception);
+			}
 
 			if (StringUtils.hasText(message)) {
 				return response(status, headers, new ExceptionMessage(exception));


### PR DESCRIPTION
If the status returned by the exception mapper is not a server error, it is working as intended. So logging on error level creates confusion and potentially hides actual implementation errors. Since client errors, and even more successful responses, should not all be logged by default, the best log level for those is debug.

A good example for the current situation are messages like this:
```
2019-12-13 11:02:30.123 ERROR 4979 --- [nio-8080-exec-7] o.s.d.r.w.RepositoryRestExceptionHandler : Parameter lookupDate in RegionRepository.findLatestRegions must not be null!

java.lang.IllegalArgumentException: Parameter lookupDate in RegionRepository.findLatestRegions must not be null!
	at org.springframework.data.repository.core.support.MethodInvocationValidator.invoke(MethodInvocationValidator.java:94) ~[spring-data-commons-2.2.3.RELEASE.jar:2.2.3.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.2.2.RELEASE.jar:5.2.2.RELEASE]
...
```
It is correctly returned as a 400 client error, because a parameter was missing. But for the maintainer, it is hard to tell if it was handled correctly or not.

PS: I did not open a ticket in Jira yet, because registering takes longer than this change. If you really need one, I will do it.