### PR TITLE
[docs] Correct resource name in query method section

### DIFF
--- a/src/main/asciidoc/repository-resources.adoc
+++ b/src/main/asciidoc/repository-resources.adoc
@@ -380,7 +380,7 @@ The query method resource runs the exposed query through an individual query met
 
 === Supported HTTP Methods
 
-As the search resource is a read-only resource, it supports `GET` only.
+As the query method resource is a read-only resource, it supports `GET` only.
 
 ==== `GET`
 


### PR DESCRIPTION
I believe this is supposed to say "query method resource" instead of "search resource" since it is in the query method resource section.  I believe it said "search" because it was copied from the search resource section above.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREST).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
