### PR TITLE
DATAREST-1068 - Resize array during merge.

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/DomainObjectReader.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/DomainObjectReader.java
@@ -62,6 +62,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * @author Mark Paluch
  * @author Craig Andrews
  * @author Mathias Düsterhöft
+ * @author Thomas Mrozinski
  * @since 2.2
  */
 @RequiredArgsConstructor
@@ -510,7 +511,7 @@ public class DomainObjectReader {
 		}
 
 		if (source.getClass().isArray()) {
-			return Arrays.asList((Object[]) source);
+			return new ArrayList<>(Arrays.asList((Object[]) source));
 		}
 
 		return null;

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/json/DomainObjectReaderUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/json/DomainObjectReaderUnitTests.java
@@ -73,6 +73,7 @@ import com.google.common.base.Charsets;
  * @author Craig Andrews
  * @author Mathias Düsterhöft
  * @author Ken Dombeck
+ * @author Thomas Mrozinski
  */
 @RunWith(MockitoJUnitRunner.class)
 public class DomainObjectReaderUnitTests {
@@ -102,6 +103,7 @@ public class DomainObjectReaderUnitTests {
 		mappingContext.getPersistentEntity(SampleWithReference.class);
 		mappingContext.getPersistentEntity(Note.class);
 		mappingContext.getPersistentEntity(WithNullCollection.class);
+		mappingContext.getPersistentEntity(ArrayHolder.class);
 		mappingContext.afterPropertiesSet();
 
 		this.entities = new PersistentEntities(Collections.singleton(mappingContext));
@@ -571,6 +573,16 @@ public class DomainObjectReaderUnitTests {
 		assertThat(result.lastLogin).isNotNull();
 		assertThat(result.email).isEqualTo("foo@bar.com");
 	}
+	
+	@Test // DATAREST-1068
+	public void arraysCanBeResizedDuringMerge() throws Exception {
+		ObjectMapper mapper = new ObjectMapper();
+		ArrayHolder target = new ArrayHolder(new String[] { });
+		JsonNode node = mapper.readTree("{ \"array\" : [ \"new\" ] }");
+		
+		ArrayHolder updated = reader.doMerge((ObjectNode) node, target, mapper);
+		assertThat(updated.array).containsExactly("new");
+	}
 
 	@SuppressWarnings("unchecked")
 	private static <T> T as(Object source, Class<T> type) {
@@ -794,5 +806,11 @@ public class DomainObjectReaderUnitTests {
 	@JsonAutoDetect(fieldVisibility = Visibility.ANY)
 	static class WithNullCollection {
 		List<String> strings;
+	}
+	
+	// DATAREST-1068
+	@Value
+	static class ArrayHolder {
+		String[] array;
 	}
 }


### PR DESCRIPTION
When merging new data into a PersistentEntity, JsonNodes of array types were deserialized into immutable Lists, but the list is later mutated if the source and target arrays are of different sizes. This commit ensures that an array is deserialized into a mutable list.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREST).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
