### PR TITLE
DATAREST-1509 - Fix Jackson ISO serialization test.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,6 +85,63 @@ pipeline {
 						sh 'MAVEN_OPTS="-Duser.name=jenkins -Duser.home=/tmp/jenkins-home" ./mvnw -Pjava11 clean dependency:list test -Dsort -U -B -Pit'
 					}
 				}
+				stage("test: spring52/jackson-next (jdk8)") {
+					agent {
+						docker {
+							image 'springci/spring-data-openjdk8-with-mongodb-4.2.0:latest'
+							label 'data'
+							args '-v $HOME:/tmp/jenkins-home'
+						}
+					}
+					options { timeout(time: 30, unit: 'MINUTES') }
+					steps {
+						sh 'rm -rf ?'
+						sh 'mkdir -p /tmp/mongodb/db /tmp/mongodb/log'
+						sh 'mongod --dbpath /tmp/mongodb/db --replSet rs0 --fork --logpath /tmp/mongodb/log/mongod.log &'
+						sh 'sleep 10'
+						sh 'mongo --eval "rs.initiate({_id: \'rs0\', members:[{_id: 0, host: \'127.0.0.1:27017\'}]});"'
+						sh 'sleep 15'
+						sh 'MAVEN_OPTS="-Duser.name=jenkins -Duser.home=/tmp/jenkins-home" ./mvnw -Pjava11 clean dependency:list test -Dsort -U -B -Pit,spring52-next,jackson-next'
+					}
+				}
+				stage("test: spring52/jackson-next (jdk11)") {
+					agent {
+						docker {
+							image 'springci/spring-data-openjdk11-with-mongodb-4.2.0:latest'
+							label 'data'
+							args '-v $HOME:/tmp/jenkins-home'
+						}
+					}
+					options { timeout(time: 30, unit: 'MINUTES') }
+					steps {
+						sh 'rm -rf ?'
+						sh 'mkdir -p /tmp/mongodb/db /tmp/mongodb/log'
+						sh 'mongod --dbpath /tmp/mongodb/db --replSet rs0 --fork --logpath /tmp/mongodb/log/mongod.log &'
+						sh 'sleep 10'
+						sh 'mongo --eval "rs.initiate({_id: \'rs0\', members:[{_id: 0, host: \'127.0.0.1:27017\'}]});"'
+						sh 'sleep 15'
+						sh 'MAVEN_OPTS="-Duser.name=jenkins -Duser.home=/tmp/jenkins-home" ./mvnw -Pjava11 clean dependency:list test -Dsort -U -B -Pit,spring52-next,jackson-next'
+					}
+				}
+				stage("test: spring52/jackson-next (jdk14)") {
+					agent {
+						docker {
+							image 'springci/spring-data-openjdk14-with-mongodb-4.2.0:latest'
+							label 'data'
+							args '-v $HOME:/tmp/jenkins-home'
+						}
+					}
+					options { timeout(time: 30, unit: 'MINUTES') }
+					steps {
+						sh 'rm -rf ?'
+						sh 'mkdir -p /tmp/mongodb/db /tmp/mongodb/log'
+						sh 'mongod --dbpath /tmp/mongodb/db --replSet rs0 --fork --logpath /tmp/mongodb/log/mongod.log &'
+						sh 'sleep 10'
+						sh 'mongo --eval "rs.initiate({_id: \'rs0\', members:[{_id: 0, host: \'127.0.0.1:27017\'}]});"'
+						sh 'sleep 15'
+						sh 'MAVEN_OPTS="-Duser.name=jenkins -Duser.home=/tmp/jenkins-home" ./mvnw -Pjava11 clean dependency:list test -Dsort -U -B -Pit,spring52-next,jenkins-next'
+					}
+				}
 			}
 		}
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-rest-parent</artifactId>
-	<version>3.3.0.BUILD-SNAPSHOT</version>
+	<version>3.3.0.DATAREST-1509-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data REST</name>

--- a/spring-data-rest-core/pom.xml
+++ b/spring-data-rest-core/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>3.3.0.BUILD-SNAPSHOT</version>
+		<version>3.3.0.DATAREST-1509-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-rest-distribution/pom.xml
+++ b/spring-data-rest-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>3.3.0.BUILD-SNAPSHOT</version>
+		<version>3.3.0.DATAREST-1509-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-rest-hal-browser/pom.xml
+++ b/spring-data-rest-hal-browser/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>3.3.0.BUILD-SNAPSHOT</version>
+		<version>3.3.0.DATAREST-1509-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-data-rest-hal-browser</artifactId>

--- a/spring-data-rest-hal-explorer/pom.xml
+++ b/spring-data-rest-hal-explorer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>3.3.0.BUILD-SNAPSHOT</version>
+		<version>3.3.0.DATAREST-1509-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-data-rest-hal-explorer</artifactId>

--- a/spring-data-rest-tests/pom.xml
+++ b/spring-data-rest-tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>3.3.0.BUILD-SNAPSHOT</version>
+		<version>3.3.0.DATAREST-1509-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-core/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.3.0.BUILD-SNAPSHOT</version>
+		<version>3.3.0.DATAREST-1509-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-webmvc</artifactId>
-			<version>3.3.0.BUILD-SNAPSHOT</version>
+			<version>3.3.0.DATAREST-1509-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-rest-tests/spring-data-rest-tests-geode/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-geode/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.3.0.BUILD-SNAPSHOT</version>
+		<version>3.3.0.DATAREST-1509-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>3.3.0.BUILD-SNAPSHOT</version>
+			<version>3.3.0.DATAREST-1509-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.3.0.BUILD-SNAPSHOT</version>
+		<version>3.3.0.DATAREST-1509-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>3.3.0.BUILD-SNAPSHOT</version>
+			<version>3.3.0.DATAREST-1509-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-mongodb/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-mongodb/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.3.0.BUILD-SNAPSHOT</version>
+		<version>3.3.0.DATAREST-1509-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>3.3.0.BUILD-SNAPSHOT</version>
+			<version>3.3.0.DATAREST-1509-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-security/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-security/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.3.0.BUILD-SNAPSHOT</version>
+		<version>3.3.0.DATAREST-1509-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>3.3.0.BUILD-SNAPSHOT</version>
+			<version>3.3.0.DATAREST-1509-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-shop/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-shop/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.3.0.BUILD-SNAPSHOT</version>
+		<version>3.3.0.DATAREST-1509-SNAPSHOT</version>
 	</parent>
 
 	<name>Spring Data REST Tests - Shop</name>

--- a/spring-data-rest-tests/spring-data-rest-tests-solr/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-solr/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.3.0.BUILD-SNAPSHOT</version>
+		<version>3.3.0.DATAREST-1509-SNAPSHOT</version>
 	</parent>
 
 	<name>Spring Data REST Tests - Solr</name>
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>3.3.0.BUILD-SNAPSHOT</version>
+			<version>3.3.0.DATAREST-1509-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-webmvc/pom.xml
+++ b/spring-data-rest-webmvc/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>3.3.0.BUILD-SNAPSHOT</version>
+		<version>3.3.0.DATAREST-1509-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/util/AssertionUtils.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/util/AssertionUtils.java
@@ -1,0 +1,22 @@
+package org.springframework.data.rest.webmvc.util;
+
+import java.util.function.Predicate;
+
+/**
+ * Various extensions of AssertJ to improve testing.
+ *
+ * @author Greg Turnquist
+ */
+public final class AssertionUtils {
+
+
+    /**
+     * {@link Predicate} to verify a given string ends in a certain pattern.
+     *
+     * @param pattern
+     * @return
+     */
+    public static Predicate<String> endsWith(String pattern) {
+        return s -> s.endsWith(pattern);
+    }
+}


### PR DESCRIPTION
Verify that Jackson properly serializes to ISO-8601 format, which includes three potential timezone endings. Expand CI testing against both Jackson 2.10 and 2.11. Also test these profiles against JDK 8, 11, and 14.

Related: https://github.com/spring-projects/spring-data-build/issues/1075

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREST).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).