### PR TITLE
Make public AbstractRepositoryRestController and RepositoryEntityController

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/AbstractRepositoryRestController.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/AbstractRepositoryRestController.java
@@ -38,9 +38,10 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
  * @author Jon Brisbin
  * @author Oliver Gierke
  * @author Thibaud Lepretre
+ * @author Luis Vargas
  */
 @SuppressWarnings({ "rawtypes" })
-class AbstractRepositoryRestController {
+public class AbstractRepositoryRestController {
 
 	private static final EmbeddedWrappers WRAPPERS = new EmbeddedWrappers(false);
 

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryEntityController.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryEntityController.java
@@ -73,9 +73,10 @@ import org.springframework.web.bind.annotation.ResponseBody;
  * @author Greg Turnquist
  * @author Jeremy Rickard
  * @author Jeroen Reijn
+ * @author Luis Vargas
  */
 @RepositoryRestController
-class RepositoryEntityController extends AbstractRepositoryRestController implements ApplicationEventPublisherAware {
+public class RepositoryEntityController extends AbstractRepositoryRestController implements ApplicationEventPublisherAware {
 
 	private static final String BASE_MAPPING = "/{repository}";
 	private static final List<String> ACCEPT_PATCH_HEADERS = Arrays.asList(//


### PR DESCRIPTION
This change will allow other developers to extend those two classes and modify their behavior.

For example:

```java
public EmployeesController extends RepositoryEntityController {
...
}
```

or:

```java
public EmployeesController extends AbstractRepositoryRestController {
...
}
```

At the same time some of their methods like `toCollectionModel` can be used in the children classes
