### PR TITLE
DATAREST-1524 - Fix deserialization of transient fiels with setters.

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/DomainObjectReader.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/DomainObjectReader.java
@@ -60,6 +60,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * @author Craig Andrews
  * @author Mathias Düsterhöft
  * @author Thomas Mrozinski
+ * @author Bas Schoenmaeckers
  * @since 2.2
  */
 public class DomainObjectReader {
@@ -235,8 +236,12 @@ public class DomainObjectReader {
 			String fieldName = entry.getKey();
 
 			if (!mappedProperties.isWritableProperty(fieldName)) {
+				PropertyAccessor targetPropertyAccessor = PropertyAccessorFactory.forBeanPropertyAccess(target);
 
-				i.remove();
+				if (!targetPropertyAccessor.isWritableProperty(fieldName)) {
+					i.remove();
+				}
+
 				continue;
 			}
 

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/json/DomainObjectReaderUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/json/DomainObjectReaderUnitTests.java
@@ -74,6 +74,7 @@ import com.google.common.base.Charsets;
  * @author Mathias Düsterhöft
  * @author Ken Dombeck
  * @author Thomas Mrozinski
+ * @author Bas Schoenmaeckers
  */
 @RunWith(MockitoJUnitRunner.class)
 public class DomainObjectReaderUnitTests {
@@ -576,6 +577,22 @@ public class DomainObjectReaderUnitTests {
 		assertThat(result.email).isEqualTo("foo@bar.com");
 	}
 
+	@Test // DATAREST-1524
+	public void useTransientSettersWithNonPersistentPropertiesForPatch() throws Exception {
+		SampleUser user = new SampleUser("name", "password");
+		user.lastLogin = new Date();
+		user.email = "foo@bar.com";
+		user.nonPersistentField = false;
+
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode source = (ObjectNode) mapper.readTree("{ \"online\" : true}");
+
+		@SuppressWarnings("deprecation")
+		SampleUser result = reader.merge(source, user, mapper);
+
+		assertThat(result.isOnline()).isTrue();
+	}
+
 	@Test // DATAREST-1068
 	public void arraysCanBeResizedDuringMerge() throws Exception {
 		ObjectMapper mapper = new ObjectMapper();
@@ -605,6 +622,22 @@ public class DomainObjectReaderUnitTests {
 
 		@ReadOnlyProperty //
 		private String email;
+
+		@Transient
+		@JsonIgnore
+		boolean nonPersistentField;
+
+		@Transient
+		@JsonProperty
+		public boolean isOnline() {
+			return nonPersistentField;
+		}
+
+		@Transient
+		@JsonProperty
+		public void setOnline(Boolean online) {
+				this.nonPersistentField = online;
+		}
 
 		public SampleUser(String name, String password) {
 


### PR DESCRIPTION
This fixes DATAREST-1524 after it was broken by DATAREST-1383.
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREST).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
