### PR TITLE
DATAREST-1567 - Replace component scan with @Bean methods. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-rest-parent</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-DATAREST-1567-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data REST</name>

--- a/spring-data-rest-core/pom.xml
+++ b/spring-data-rest-core/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-DATAREST-1567-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-rest-distribution/pom.xml
+++ b/spring-data-rest-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-DATAREST-1567-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-rest-hal-explorer/pom.xml
+++ b/spring-data-rest-hal-explorer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-DATAREST-1567-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-data-rest-hal-explorer</artifactId>

--- a/spring-data-rest-hal-explorer/src/main/java/org/springframework/data/rest/webmvc/halexplorer/HalExplorerConfiguration.java
+++ b/spring-data-rest-hal-explorer/src/main/java/org/springframework/data/rest/webmvc/halexplorer/HalExplorerConfiguration.java
@@ -45,15 +45,14 @@ class HalExplorerConfiguration implements StaticResourceProvider {
 	}
 
 	/**
-	 * The controller that exposes the {@link HalExplorer}.
+	 * The controller that exposes the {@link HalExplorer}. TODO: Maybe register this one directly on mvc via
+	 * WebMvcConfigurer.addViewCntroller(…)?
 	 *
 	 * @return never {@literal null}.
 	 * @since 3.4
 	 */
 	@Bean
 	HalExplorer halExplorer() {
-
-		// TODO: maybe register this one directly on mvc via WebMvcConfigurer.addRedirectVieController()
 		return new HalExplorer();
 	}
 }

--- a/spring-data-rest-hal-explorer/src/main/java/org/springframework/data/rest/webmvc/halexplorer/HalExplorerConfiguration.java
+++ b/spring-data-rest-hal-explorer/src/main/java/org/springframework/data/rest/webmvc/halexplorer/HalExplorerConfiguration.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.rest.webmvc.halexplorer;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.webmvc.config.StaticResourceProvider;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
@@ -23,9 +25,11 @@ import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
  * {@link StaticResourceProvider} to expose the HAL Browser WebJar content via a static resource route.
  *
  * @author Oliver Drotbohm
+ * @author Christoph Strobl
  * @since 3.2
  * @soundtrack Tedeschi Trucks Band - Signs, High Times (Signs)
  */
+@Configuration(proxyBeanMethods = false)
 class HalExplorerConfiguration implements StaticResourceProvider {
 
 	/*
@@ -38,5 +42,18 @@ class HalExplorerConfiguration implements StaticResourceProvider {
 		String rootLocation = "classpath:META-INF/spring-data-rest/hal-explorer/";
 
 		registry.addResourceHandler(basePath.concat("/**")).addResourceLocations(rootLocation);
+	}
+
+	/**
+	 * The controller that exposes the {@link HalExplorer}.
+	 *
+	 * @return never {@literal null}.
+	 * @since 3.4
+	 */
+	@Bean
+	HalExplorer halExplorer() {
+
+		// TODO: maybe register this one directly on mvc via WebMvcConfigurer.addRedirectVieController()
+		return new HalExplorer();
 	}
 }

--- a/spring-data-rest-tests/pom.xml
+++ b/spring-data-rest-tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-DATAREST-1567-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-core/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-DATAREST-1567-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-webmvc</artifactId>
-			<version>3.4.0-SNAPSHOT</version>
+			<version>3.4.0-DATAREST-1567-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-rest-tests/spring-data-rest-tests-geode/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-geode/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-DATAREST-1567-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>3.4.0-SNAPSHOT</version>
+			<version>3.4.0-DATAREST-1567-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-DATAREST-1567-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>3.4.0-SNAPSHOT</version>
+			<version>3.4.0-DATAREST-1567-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/CorsIntegrationTests.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/CorsIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 original author or authors.
+ * Copyright 2016-2020 original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.Test;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.rest.tests.AbstractWebIntegrationTests;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryRestController;
@@ -46,7 +47,23 @@ import org.springframework.web.bind.annotation.RequestMethod;
 @ContextConfiguration
 public class CorsIntegrationTests extends AbstractWebIntegrationTests {
 
+	@Configuration
 	static class CorsConfig extends JpaRepositoryConfig {
+
+		@Bean
+		AuthorsPdfController authorsPdfController() {
+			return new AuthorsPdfController();
+		}
+
+		@Bean
+		BooksPdfController booksPdfController() {
+			return new BooksPdfController();
+		}
+
+		@Bean
+		BooksXmlController booksXmlController() {
+			return new BooksXmlController();
+		}
 
 		@Bean
 		RepositoryRestConfigurer repositoryRestConfigurer() {

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaDefaultPageableWebTests.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaDefaultPageableWebTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 original author or authors.
+ * Copyright 2016-2020 original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,16 +23,15 @@ import java.util.Collections;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.tests.AbstractWebIntegrationTests;
 import org.springframework.data.rest.webmvc.RepositoryRestController;
 import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
@@ -41,8 +40,6 @@ import org.springframework.hateoas.IanaLinkRelations;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.LinkRelation;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -52,18 +49,22 @@ import org.springframework.web.bind.annotation.ResponseBody;
  *
  * @author Mark Paluch
  */
-@RunWith(SpringRunner.class)
-@WebAppConfiguration
-@ContextConfiguration(classes = JpaDefaultPageableWebTests.Config.class)
+@ContextConfiguration
 public class JpaDefaultPageableWebTests extends AbstractWebIntegrationTests {
 
 	@Configuration
 	@Import({ RepositoryRestMvcConfiguration.class, JpaRepositoryConfig.class })
 	@EnableJpaRepositories(considerNestedRepositories = true)
-	static class Config implements RepositoryRestConfigurer {
+	static class Config {
 
-		public void configureRepositoryRestConfiguration(RepositoryRestConfiguration config) {
-			config.setDefaultPageSize(1);
+		@Bean
+		MyRestController myRestController() {
+			return new MyRestController();
+		}
+
+		@Bean
+		RepositoryRestConfigurer repositoryRestConfigurer() {
+			return RepositoryRestConfigurer.withConfig(config -> config.setDefaultPageSize(1));
 		}
 	}
 

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaWebTests.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaWebTests.java
@@ -17,12 +17,14 @@ package org.springframework.data.rest.webmvc.jpa;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 import static org.springframework.data.rest.webmvc.util.TestUtils.*;
 import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import net.minidev.json.JSONArray;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -30,12 +32,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import net.minidev.json.JSONArray;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.data.rest.core.mapping.ResourceMappings;
 import org.springframework.data.rest.tests.CommonWebTests;
+import org.springframework.data.rest.webmvc.jpa.JpaRepositoryConfig.BooksHtmlController;
+import org.springframework.data.rest.webmvc.jpa.JpaRepositoryConfig.OrdersJsonController;
 import org.springframework.hateoas.IanaLinkRelations;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.LinkRelation;
@@ -63,7 +68,7 @@ import com.jayway.jsonpath.JsonPath;
  * @author Ľubomír Varga
  */
 @Transactional
-@ContextConfiguration(classes = JpaRepositoryConfig.class)
+@ContextConfiguration(classes = JpaRepositoryConfig.class, initializers = JpaWebTests.JpaContextInitializer.class)
 public class JpaWebTests extends CommonWebTests {
 
 	private static final MediaType TEXT_URI_LIST = MediaType.valueOf("text/uri-list");
@@ -74,6 +79,17 @@ public class JpaWebTests extends CommonWebTests {
 	@Autowired LinkRelationProvider relProvider;
 
 	ObjectMapper mapper = new ObjectMapper();
+
+	static class JpaContextInitializer implements ApplicationContextInitializer<GenericApplicationContext> {
+
+		@Override
+		public void initialize(GenericApplicationContext ctx) {
+
+			ctx.registerBean(AuthorsController.class);
+			ctx.registerBean(BooksHtmlController.class);
+			ctx.registerBean(OrdersJsonController.class);
+		}
+	}
 
 	/*
 	 * (non-Javadoc)

--- a/spring-data-rest-tests/spring-data-rest-tests-mongodb/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-mongodb/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-DATAREST-1567-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>3.4.0-SNAPSHOT</version>
+			<version>3.4.0-DATAREST-1567-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-security/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-security/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-DATAREST-1567-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>3.4.0-SNAPSHOT</version>
+			<version>3.4.0-DATAREST-1567-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-tests/spring-data-rest-tests-shop/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-shop/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-DATAREST-1567-SNAPSHOT</version>
 	</parent>
 
 	<name>Spring Data REST Tests - Shop</name>

--- a/spring-data-rest-tests/spring-data-rest-tests-solr/pom.xml
+++ b/spring-data-rest-tests/spring-data-rest-tests-solr/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-tests</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-DATAREST-1567-SNAPSHOT</version>
 	</parent>
 
 	<name>Spring Data REST Tests - Solr</name>
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-tests-core</artifactId>
-			<version>3.4.0-SNAPSHOT</version>
+			<version>3.4.0-DATAREST-1567-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 

--- a/spring-data-rest-webmvc/pom.xml
+++ b/spring-data-rest-webmvc/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-rest-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-DATAREST-1567-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RestControllerConfiguration.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RestControllerConfiguration.java
@@ -61,7 +61,7 @@ public class RestControllerConfiguration {
 	 * @return never {@literal null}.
 	 */
 	@Bean
-	protected RepositoryController repositoryController(EntityLinks entityLinks) {
+	RepositoryController repositoryController(EntityLinks entityLinks) {
 		return new RepositoryController(resourcesAssembler, repositories, entityLinks, resourceMappings);
 	}
 
@@ -74,7 +74,7 @@ public class RestControllerConfiguration {
 	 * @return never {@literal null}.
 	 */
 	@Bean
-	protected RepositoryEntityController repositoryEntityController(RepositoryEntityLinks entityLinks,
+	RepositoryEntityController repositoryEntityController(RepositoryEntityLinks entityLinks,
 			HttpHeadersPreparer headersPreparer) {
 		return new RepositoryEntityController(repositories, restConfiguration, entityLinks, resourcesAssembler,
 				headersPreparer);
@@ -87,7 +87,7 @@ public class RestControllerConfiguration {
 	 * @return never {@literal null}.
 	 */
 	@Bean
-	protected RepositoryPropertyReferenceController repositoryPropertyReferenceController(
+	RepositoryPropertyReferenceController repositoryPropertyReferenceController(
 			RepositoryInvokerFactory repositoryInvokerFactory) {
 		return new RepositoryPropertyReferenceController(repositories, repositoryInvokerFactory, resourcesAssembler);
 	}
@@ -101,7 +101,7 @@ public class RestControllerConfiguration {
 	 * @return never {@literal null}.
 	 */
 	@Bean
-	protected RepositorySearchController repositorySearchController(RepositoryEntityLinks entityLinks,
+	RepositorySearchController repositorySearchController(RepositoryEntityLinks entityLinks,
 			HttpHeadersPreparer headersPreparer) {
 		return new RepositorySearchController(resourcesAssembler, entityLinks, resourceMappings, headersPreparer);
 	}
@@ -113,7 +113,7 @@ public class RestControllerConfiguration {
 	 * @return never {@literal null}.
 	 */
 	@Bean
-	protected RepositorySchemaController repositorySchemaController(
+	RepositorySchemaController repositorySchemaController(
 			PersistentEntityToJsonSchemaConverter jsonSchemaConverter) {
 		return new RepositorySchemaController(jsonSchemaConverter);
 	}
@@ -125,7 +125,7 @@ public class RestControllerConfiguration {
 	 * @return never {@literal null}.
 	 */
 	@Bean
-	protected AlpsController alpsController() {
+	AlpsController alpsController() {
 		return new AlpsController(restConfiguration);
 	}
 
@@ -135,7 +135,7 @@ public class RestControllerConfiguration {
 	 * @return never {@literal null}.
 	 */
 	@Bean
-	protected ProfileController profileController() {
+	ProfileController profileController() {
 		return new ProfileController(restConfiguration, resourceMappings, repositories);
 	}
 }

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RestControllerConfiguration.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RestControllerConfiguration.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.webmvc;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.repository.support.Repositories;
+import org.springframework.data.repository.support.RepositoryInvokerFactory;
+import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
+import org.springframework.data.rest.core.mapping.RepositoryResourceMappings;
+import org.springframework.data.rest.webmvc.alps.AlpsController;
+import org.springframework.data.rest.webmvc.json.JsonSchema;
+import org.springframework.data.rest.webmvc.json.PersistentEntityToJsonSchemaConverter;
+import org.springframework.data.rest.webmvc.support.RepositoryEntityLinks;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.server.EntityLinks;
+
+/**
+ * Configuration class registering required {@link org.springframework.stereotype.Component components} that declare
+ * request mappings as {@link Bean beans}.
+ *
+ * @author Christoph Strobl
+ * @since 3.4
+ */
+@Configuration(proxyBeanMethods = false)
+public class RestControllerConfiguration {
+
+	private final RepositoryRestConfiguration restConfiguration;
+	private final RepositoryResourceMappings resourceMappings;
+	private final PagedResourcesAssembler<Object> resourcesAssembler;
+	private final Repositories repositories;
+
+	RestControllerConfiguration(RepositoryRestConfiguration restConfiguration,
+			RepositoryResourceMappings resourceMappings, PagedResourcesAssembler<Object> resourcesAssembler,
+			Repositories repositories) {
+
+		this.restConfiguration = restConfiguration;
+		this.resourceMappings = resourceMappings;
+		this.resourcesAssembler = resourcesAssembler;
+		this.repositories = repositories;
+	}
+
+	/**
+	 * The controller for the root resource exposing links to the repository resources.
+	 *
+	 * @param entityLinks the accessor to links pointing to controllers backing an entity type. Must not be
+	 *          {@literal null}.
+	 * @return never {@literal null}.
+	 */
+	@Bean
+	protected RepositoryController repositoryController(EntityLinks entityLinks) {
+		return new RepositoryController(resourcesAssembler, repositories, entityLinks, resourceMappings);
+	}
+
+	/**
+	 * The root controller for entities reachable via {@code /{repository}}.
+	 *
+	 * @param entityLinks the accessor to links pointing to controllers backing an entity type. Must not be *
+	 *          {@literal null}.
+	 * @param headersPreparer must not be {@literal null}.
+	 * @return never {@literal null}.
+	 */
+	@Bean
+	protected RepositoryEntityController repositoryEntityController(RepositoryEntityLinks entityLinks,
+			HttpHeadersPreparer headersPreparer) {
+		return new RepositoryEntityController(repositories, restConfiguration, entityLinks, resourcesAssembler,
+				headersPreparer);
+	}
+
+	/**
+	 * The controller to access referenced properties via {@code /{repository}/{id}/{property}}.
+	 *
+	 * @param repositoryInvokerFactory must not be {@literal null}.
+	 * @return never {@literal null}.
+	 */
+	@Bean
+	protected RepositoryPropertyReferenceController repositoryPropertyReferenceController(
+			RepositoryInvokerFactory repositoryInvokerFactory) {
+		return new RepositoryPropertyReferenceController(repositories, repositoryInvokerFactory, resourcesAssembler);
+	}
+
+	/**
+	 * The controller that performs lookups and executes searches.
+	 *
+	 * @param entityLinks he accessor to links pointing to controllers backing an entity type. Must not be *
+	 *          {@literal null}.
+	 * @param headersPreparer must not be {@literal null}.
+	 * @return never {@literal null}.
+	 */
+	@Bean
+	protected RepositorySearchController repositorySearchController(RepositoryEntityLinks entityLinks,
+			HttpHeadersPreparer headersPreparer) {
+		return new RepositorySearchController(resourcesAssembler, entityLinks, resourceMappings, headersPreparer);
+	}
+
+	/**
+	 * The controller that exposes the JSON schema via {@code /repository/schema}.
+	 *
+	 * @param jsonSchemaConverter the converter to create the {@link JsonSchema}. Must not be {@literal null}.
+	 * @return never {@literal null}.
+	 */
+	@Bean
+	protected RepositorySchemaController repositorySchemaController(
+			PersistentEntityToJsonSchemaConverter jsonSchemaConverter) {
+		return new RepositorySchemaController(jsonSchemaConverter);
+	}
+
+	/**
+	 * The controller that exposes semantic documentation in the <a href="http://alps.io/">ALPS</a> (Application Level
+	 * Profile Semantics) format.
+	 *
+	 * @return never {@literal null}.
+	 */
+	@Bean
+	protected AlpsController alpsController() {
+		return new AlpsController(restConfiguration);
+	}
+
+	/**
+	 * Profile-based controller exposing multiple forms of metadata via {@code /profile}.
+	 *
+	 * @return never {@literal null}.
+	 */
+	@Bean
+	protected ProfileController profileController() {
+		return new ProfileController(restConfiguration, resourceMappings, repositories);
+	}
+}

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
@@ -32,8 +32,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportResource;
@@ -144,13 +142,13 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
  * @author Jon Brisbin
  * @author Greg Turnquist
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 @Configuration(proxyBeanMethods = false)
 @EnableHypermediaSupport(type = HypermediaType.HAL)
-@ComponentScan(basePackageClasses = RepositoryRestController.class,
-		includeFilters = @Filter(BasePathAwareController.class), useDefaultFilters = false)
 @ImportResource("classpath*:META-INF/spring-data-rest/**/*.xml")
-@Import({ SpringDataJacksonConfiguration.class, EnableSpringDataWebSupport.QuerydslActivator.class })
+@Import({ RestControllerImportSelector.class, SpringDataJacksonConfiguration.class,
+		EnableSpringDataWebSupport.QuerydslActivator.class })
 public class RepositoryRestMvcConfiguration extends HateoasAwareSpringDataWebConfiguration
 		implements BeanClassLoaderAware {
 

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
@@ -147,7 +147,8 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 @Configuration(proxyBeanMethods = false)
 @EnableHypermediaSupport(type = HypermediaType.HAL)
 @ImportResource("classpath*:META-INF/spring-data-rest/**/*.xml")
-@Import({ RestControllerImportSelector.class, SpringDataJacksonConfiguration.class,
+@Import({ RestControllerImportSelector.class, //
+		SpringDataJacksonConfiguration.class, //
 		EnableSpringDataWebSupport.QuerydslActivator.class })
 public class RepositoryRestMvcConfiguration extends HateoasAwareSpringDataWebConfiguration
 		implements BeanClassLoaderAware {

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RestControllerImportSelector.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RestControllerImportSelector.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.webmvc.config;
+
+import org.springframework.context.annotation.ImportSelector;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.data.rest.webmvc.RestControllerConfiguration;
+import org.springframework.util.ClassUtils;
+
+/**
+ * {@link ImportSelector} choosing additional controller configuration (eg. for the {@litearl Hal Explorer}) when
+ * present.
+ *
+ * @author Christoph Strobl
+ * @since 3.4
+ */
+class RestControllerImportSelector implements ImportSelector {
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.context.annotation.ImportSelector#selectImports(org.springframework.core.type.AnnotationMetadata)
+	 */
+	@Override
+	public String[] selectImports(AnnotationMetadata importingClassMetadata) {
+
+		if (ClassUtils.isPresent("org.springframework.data.rest.webmvc.halexplorer.HalExplorerConfiguration",
+				importingClassMetadata.getClass().getClassLoader())) {
+
+			return new String[] { RestControllerConfiguration.class.getName(),
+					"org.springframework.data.rest.webmvc.halexplorer.HalExplorerConfiguration" };
+		}
+
+		return new String[] { RestControllerConfiguration.class.getName() };
+	}
+}

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RestControllerImportSelector.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RestControllerImportSelector.java
@@ -15,6 +15,9 @@
  */
 package org.springframework.data.rest.webmvc.config;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.context.annotation.ImportSelector;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.data.rest.webmvc.RestControllerConfiguration;
@@ -25,9 +28,12 @@ import org.springframework.util.ClassUtils;
  * present.
  *
  * @author Christoph Strobl
+ * @author Oliver Drotbohm
  * @since 3.4
  */
 class RestControllerImportSelector implements ImportSelector {
+
+	private static final String HAL_EXPLORER_CONFIGURATION = "org.springframework.data.rest.webmvc.halexplorer.HalExplorerConfiguration";
 
 	/*
 	 * (non-Javadoc)
@@ -36,13 +42,13 @@ class RestControllerImportSelector implements ImportSelector {
 	@Override
 	public String[] selectImports(AnnotationMetadata importingClassMetadata) {
 
-		if (ClassUtils.isPresent("org.springframework.data.rest.webmvc.halexplorer.HalExplorerConfiguration",
-				importingClassMetadata.getClass().getClassLoader())) {
+		List<String> configurations = new ArrayList<>();
+		configurations.add(RestControllerConfiguration.class.getName());
 
-			return new String[] { RestControllerConfiguration.class.getName(),
-					"org.springframework.data.rest.webmvc.halexplorer.HalExplorerConfiguration" };
+		if (ClassUtils.isPresent(HAL_EXPLORER_CONFIGURATION, importingClassMetadata.getClass().getClassLoader())) {
+			configurations.add(HAL_EXPLORER_CONFIGURATION);
 		}
 
-		return new String[] { RestControllerConfiguration.class.getName() };
+		return configurations.toArray(new String[configurations.size()]);
 	}
 }


### PR DESCRIPTION
We replaced the component scan in `RespositoryRestMvcConfiguration` with dedicated bean methods. This allows us to be more explicit in resolving required components, which is required for better support of GraalVM native image.

Relates to: spring-projects-experimental/spring-graalvm-native#192