### PR TITLE
docs: fixes RepositoryEntityLinks method

### DIFF
--- a/src/main/asciidoc/integration.adoc
+++ b/src/main/asciidoc/integration.adoc
@@ -40,7 +40,7 @@ With the class in the preceding example, you can use the following operations:
 |`entityLinks.linkToCollectionResource(Person.class)`
 |Provide a link to the collection resource of the specified type (`Person`, in this case).
 
-|`entityLinks.linkToSingleResource(Person.class, 1)`
+|`entityLinks.linkToItemResource(Person.class, 1)`
 |Provide a link to a single resource.
 
 |`entityLinks.linkToPagedResource(Person.class, new PageRequest(...))`


### PR DESCRIPTION
The method `RepositoryEntityLinks.linkToSingleResource(Class<?> type, Object id)`  does not exists. It should be `.linkToItemResource(Class<?> type, Object id)`

I guess this has been renamed at some point in the past ?

See javadoc [RepositoryEntityLinks](https://docs.spring.io/spring-data/rest/docs/current/api/org/springframework/data/rest/webmvc/support/RepositoryEntityLinks.html#linkToItemResource-java.lang.Class-java.lang.Object-)