### PR TITLE
Fix supported mediaTypes in jacksonHttpMessageConverter.

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
@@ -143,6 +143,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
  * @author Greg Turnquist
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Sebastian Ullrich
  */
 @Configuration(proxyBeanMethods = false)
 @EnableHypermediaSupport(type = { HypermediaType.HAL, HypermediaType.HAL_FORMS })
@@ -537,7 +538,7 @@ public class RepositoryRestMvcConfiguration extends HateoasAwareSpringDataWebCon
 		int order = repositoryRestConfiguration.useHalAsDefaultJsonMediaType() ? Ordered.LOWEST_PRECEDENCE - 1
 				: Ordered.LOWEST_PRECEDENCE - 10;
 
-		mediaTypes.addAll(Arrays.asList(RestMediaTypes.SCHEMA_JSON, //
+		mediaTypes.addAll(Arrays.asList(RestMediaTypes.HAL_JSON, RestMediaTypes.SCHEMA_JSON, //
 				RestMediaTypes.JSON_PATCH_JSON, RestMediaTypes.MERGE_PATCH_JSON, //
 				RestMediaTypes.SPRING_DATA_VERBOSE_JSON, RestMediaTypes.SPRING_DATA_COMPACT_JSON));
 

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvConfigurationIntegrationTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvConfigurationIntegrationTests.java
@@ -213,7 +213,7 @@ public class RepositoryRestMvConfigurationIntegrationTests {
 				.containsSequence(userConfig.otherConfigurer(), userConfig.configurer());
 	}
 
-	@Test // DATAREST-2023
+	@Test // #2023
 	public void messageConverterSupportsRelevantMediaTypes() {
 		TypeConstrainedMappingJackson2HttpMessageConverter converter = context.getBean("jacksonHttpMessageConverter",
 				TypeConstrainedMappingJackson2HttpMessageConverter.class);
@@ -224,7 +224,7 @@ public class RepositoryRestMvConfigurationIntegrationTests {
 						RestMediaTypes.SPRING_DATA_VERBOSE_JSON, RestMediaTypes.SPRING_DATA_COMPACT_JSON);
 	}
 
-	@Test // DATAREST-2023
+	@Test // #2023
 	public void messageConverterSupportsRelevantMediaTypeIfHalIsDisabledAsDefaultMediaType() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(NonHalConfiguration.class);
 		TypeConstrainedMappingJackson2HttpMessageConverter converter = context.getBean("jacksonHttpMessageConverter",

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvConfigurationIntegrationTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvConfigurationIntegrationTests.java
@@ -53,6 +53,7 @@ import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.client.LinkDiscoverers;
 import org.springframework.hateoas.server.core.DefaultLinkRelationProvider;
 import org.springframework.hateoas.server.mvc.TypeConstrainedMappingJackson2HttpMessageConverter;
+import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -69,6 +70,7 @@ import com.jayway.jsonpath.JsonPath;
  * @author Oliver Gierke
  * @author Mark Paluch
  * @author Greg Turnquist
+ * @author Sebastian Ullrich
  */
 public class RepositoryRestMvConfigurationIntegrationTests {
 
@@ -209,6 +211,27 @@ public class RepositoryRestMvConfigurationIntegrationTests {
 
 		assertThat(Streamable.of(configurations).toList())
 				.containsSequence(userConfig.otherConfigurer(), userConfig.configurer());
+	}
+
+	@Test // DATAREST-2023
+	public void messageConverterSupportsRelevantMediaTypes() {
+		TypeConstrainedMappingJackson2HttpMessageConverter converter = context.getBean("jacksonHttpMessageConverter",
+				TypeConstrainedMappingJackson2HttpMessageConverter.class);
+
+		assertThat(converter.getSupportedMediaTypes())
+				.contains(RestMediaTypes.HAL_JSON, RestMediaTypes.SCHEMA_JSON, //
+						RestMediaTypes.JSON_PATCH_JSON, RestMediaTypes.MERGE_PATCH_JSON, //
+						RestMediaTypes.SPRING_DATA_VERBOSE_JSON, RestMediaTypes.SPRING_DATA_COMPACT_JSON);
+	}
+
+	@Test // DATAREST-2023
+	public void messageConverterSupportsRelevantMediaTypeIfHalIsDisabledAsDefaultMediaType() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(NonHalConfiguration.class);
+		TypeConstrainedMappingJackson2HttpMessageConverter converter = context.getBean("jacksonHttpMessageConverter",
+				TypeConstrainedMappingJackson2HttpMessageConverter.class);
+
+		assertThat(converter.getSupportedMediaTypes())
+				.contains(MediaType.APPLICATION_JSON);
 	}
 
 	private static ObjectMapper getObjectMapper() {


### PR DESCRIPTION
Added `application/hal+json` as supported media type to the default `jacksonHttpMessageConverter`. 
This fixes #2023.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

This is my first PR, hope I did everything accordingly. 
Please reach out to me if I can improve something.