### PR TITLE
docs: fix link to HAL Explorer doc in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,7 +17,7 @@ The first exporter implemented is a JPA Repository exporter. This takes your JPA
 * Allows to https://docs.spring.io/spring-data/rest/docs/current/reference/html/#events[hook into the handling of REST requests] by handling Spring `ApplicationEvents`.
 * https://docs.spring.io/spring-data/rest/docs/current/reference/html/#metadata[Exposes metadata] about the model discovered as ALPS and JSON Schema.
 * Allows to define client specific representations through https://docs.spring.io/spring-data/rest/docs/current/reference/html/#projections-excerpts[projections].
-* Ships the latest release of https://docs.spring.io/spring-data/rest/docs/current/reference/html/#hal-explorer[HAL Explorer] to easily explore HAL based HTTP responses.
+* Ships the latest release of https://docs.spring.io/spring-data/rest/docs/current/reference/html/#tools.hal-explorer[HAL Explorer] to easily explore HAL and HAL-FORMS based HTTP responses.
 * Currently supports JPA, MongoDB, Neo4j, Solr, Cassandra, Gemfire.
 * Allows https://docs.spring.io/spring-data/rest/docs/current/reference/html/#customizing-sdr[advanced customizations] of the default resources exposed.
 


### PR DESCRIPTION
Fixes the broken link to HAL Explorer in README.adoc.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
