### PR TITLE
Avoid wiping non-writable fields in nested objects when modifying a persistent object using PUT

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/DomainObjectReader.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/DomainObjectReader.java
@@ -61,6 +61,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * @author Craig Andrews
  * @author Mathias Düsterhöft
  * @author Thomas Mrozinski
+ * @author Lars Vierbergen
  * @since 2.2
  */
 public class DomainObjectReader {
@@ -678,7 +679,7 @@ public class DomainObjectReader {
 			} else if (property.isCollectionLike()) {
 				result = mergeCollections(property, sourceValue, targetValue, mapper);
 			} else if (property.isEntity()) {
-				result = mergeForPut(sourceValue, targetValue, mapper);
+				result = Optional.ofNullable(mergeForPut(sourceValue.orElse(null), targetValue.orElse(null), mapper));
 			} else {
 				result = sourceValue;
 			}


### PR DESCRIPTION
Because `#mergeForPut()` fetches the `PersistentEntity` based on the
class of `target`, we can't pass `Optional<>` as source or target, as
that would lead to nested objects (e.g. JPA `@Embeddable`) are not
considered as persistent entities.

That leads to properties of that are `@JsonIgnored` or `@JsonProperty(access = READ_ONLY)` to
be null'ed, because the freshly deserialized source object is used
directly, and those properties are never written to by jackson.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
