### PR TITLE
Support Validation for fields the type of which is not a PersistentEntity

### DIFF
--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/ValidationErrors.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/ValidationErrors.java
@@ -18,6 +18,7 @@ package org.springframework.data.rest.core;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Optional;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.ConfigurablePropertyAccessor;
@@ -39,6 +40,7 @@ import org.springframework.validation.Errors;
  *
  * @author Jon Brisbin
  * @author Oliver Gierke
+ * @author Florian Cramer
  */
 public class ValidationErrors extends AbstractPropertyBindingResult {
 
@@ -92,7 +94,12 @@ public class ValidationErrors extends AbstractPropertyBindingResult {
 			 */
 			private Object lookupValueOn(Object value, String segment) {
 
-				PersistentProperty<?> property = entities.getPersistentEntity(value.getClass()) //
+				Optional<PersistentEntity<?, ? extends PersistentProperty<?>>> entity = entities.getPersistentEntity(value.getClass());
+				if (!entity.isPresent()) {
+					return new DirectFieldAccessor(value).getPropertyValue(segment);
+				}
+
+				PersistentProperty<?> property = entity //
 						.map(it -> it.getPersistentProperty(PropertyAccessorUtils.getPropertyName(segment))) //
 						.orElseThrow(() -> new NotReadablePropertyException(value.getClass(), segment));
 


### PR DESCRIPTION
This change is required to perform validation on converted fields of JPA entities. Their types might not be managed types and as such no JPAPersistentEntity instances are created for them. Before these changes this would result in a NotReadablePropertyException every time there is a validation error in one of those fields.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
