### PR TITLE
DATAREST-1280 Add support sort collection resource by associated property.

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/JacksonMappingAwareSortTranslator.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/JacksonMappingAwareSortTranslator.java
@@ -192,10 +192,6 @@ public class JacksonMappingAwareSortTranslator {
 
 				for (PersistentProperty<?> persistentProperty : persistentProperties) {
 
-					if (associations.isLinkableAssociation(persistentProperty)) {
-						return Collections.emptyList();
-					}
-
 					persistentPropertyPath.add(persistentProperty.getName());
 				}
 

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/json/SortTranslatorUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/json/SortTranslatorUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 original author or authors.
+ * Copyright 2016-2023 original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,19 +117,19 @@ class SortTranslatorUnitTests {
 		assertThat(translatedSort.getOrderFor("embedded.someInterface")).isNotNull();
 	}
 
+	@Test // DATAREST-1280
+	void shouldKnownAssociationProperties() {
+
+		Sort translatedSort = sortTranslator.translateSort(Sort.by("association.name"),
+				mappingContext.getRequiredPersistentEntity(Plain.class));
+
+		assertTrue(translatedSort.isSorted());
+	}
+
 	@Test // DATAREST-910
 	void shouldSkipWrongNestedProperties() {
 
 		Sort translatedSort = sortTranslator.translateSort(Sort.by("embedded.unknown"),
-				mappingContext.getRequiredPersistentEntity(Plain.class));
-
-		assertThat(translatedSort).isEqualTo(Sort.unsorted());
-	}
-
-	@Test // DATAREST-910, DATAREST-976
-	void shouldSkipKnownAssociationProperties() {
-
-		Sort translatedSort = sortTranslator.translateSort(Sort.by("association.name"),
 				mappingContext.getRequiredPersistentEntity(Plain.class));
 
 		assertThat(translatedSort).isEqualTo(Sort.unsorted());


### PR DESCRIPTION
Closes #1641
Related tickets #1386 #1343


I delete those code and execute sort 4 patterns.

https://github.com/spring-projects/spring-data-rest/blob/f0e86b9a176bbaf43fbc3fba62e935c691e35222/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/JacksonMappingAwareSortTranslator.java#L195-L197

Currently, it seems to support linkable associations.
Therefore, I have removed the check process for linkable associations.

Are there any other patterns that should be tested further?

Patterns result:

<details>
    <summary><b>eager and exported</b></summary>

Path: `/accounts_eager_and_exported?sort=accountType.typeName,desc`

Query:

```
Hibernate: select a1_0.id,a1_0.account_type_id,a1_0.name from account a1_0 left join account_type a2_0 on a2_0.id=a1_0.account_type_id order by a2_0.type_name desc offset ? rows fetch first ? rows only
```

<details>
    <summary>Entity: AccountEagerAndExported.java</summary>

```java
package dev.mikoto2000.study.springboot.data.rest.example.entity;

import jakarta.persistence.Entity;
import jakarta.persistence.FetchType;
import jakarta.persistence.GeneratedValue;
import jakarta.persistence.GenerationType;
import jakarta.persistence.Id;
import jakarta.persistence.JoinColumn;
import jakarta.persistence.ManyToOne;
import jakarta.persistence.Table;
import lombok.Data;
import org.springframework.data.rest.core.annotation.RestResource;

@Data
@Entity
@Table(name = "account")
public class AccountEagerAndExported {

    @Id
    @GeneratedValue(strategy = GenerationType.AUTO)
    private Long id;

    private String name;

    @RestResource(exported = true)
    @JoinColumn(name = "account_type_id")
    @ManyToOne(fetch = FetchType.EAGER)
    private AccountType accountType;
}
```

</details>

<details>
    <summary>Repository: AccountEagerAndExportedRepository.java</summary>

```java
package dev.mikoto2000.study.springboot.data.rest.example.repository;

import org.springframework.data.jpa.repository.JpaRepository;
import org.springframework.data.rest.core.annotation.RepositoryRestResource;

import dev.mikoto2000.study.springboot.data.rest.example.entity.AccountEagerAndExported;

@RepositoryRestResource(collectionResourceRel = "accounts_eager_and_exported", path = "accounts_eager_and_exported")
public interface AccountEagerAndExportedRepository extends JpaRepository<AccountEagerAndExported, Long> {
    
}
```

</details>

</details>

<details>
    <summary><b>eager and no exported</b></summary>

Path: `/accounts_eager_and_no_exported?sort=accountType.typeName,desc`

Query:

```sql
Hibernate: select a1_0.id,a1_0.account_type_id,a1_0.name from account a1_0 left join account_type a2_0 on a2_0.id=a1_0.account_type_id order by a2_0.type_name desc offset ? rows fetch first ? rows only
```

<details>
    <summary>Entity: AccountEagerAndNoExported.java</summary>

```java
package dev.mikoto2000.study.springboot.data.rest.example.entity;

import jakarta.persistence.Entity;
import jakarta.persistence.FetchType;
import jakarta.persistence.GeneratedValue;
import jakarta.persistence.GenerationType;
import jakarta.persistence.Id;
import jakarta.persistence.JoinColumn;
import jakarta.persistence.ManyToOne;
import jakarta.persistence.Table;
import lombok.Data;
import org.springframework.data.rest.core.annotation.RestResource;

@Data
@Entity
@Table(name = "account")
public class AccountEagerAndNoExported {

    @Id
    @GeneratedValue(strategy = GenerationType.AUTO)
    private Long id;

    private String name;

    @RestResource(exported = false)
    @JoinColumn(name = "account_type_id")
    @ManyToOne(fetch = FetchType.EAGER)
    private AccountType accountType;
}
```

</details>

<details>
    <summary>Repository: AccountEagerAndNoExportedRepository.java</summary>

```java
package dev.mikoto2000.study.springboot.data.rest.example.repository;

import org.springframework.data.jpa.repository.JpaRepository;
import org.springframework.data.rest.core.annotation.RepositoryRestResource;

import dev.mikoto2000.study.springboot.data.rest.example.entity.AccountEagerAndNoExported;

@RepositoryRestResource(collectionResourceRel = "accounts_eager_and_no_exported", path = "accounts_eager_and_no_exported")
public interface AccountEagerAndNoExportedRepository extends JpaRepository<AccountEagerAndNoExported, Long> {
    
}
```

</details>

</details>

<details>
    <summary><b>lazy and exported</b></summary>

Path: `accounts_lazy_and_exported?sort=accountType.typeName,desc`

Query:

```
Hibernate: select a1_0.id,a1_0.account_type_id,a1_0.name from account a1_0 left join account_type a2_0 on a2_0.id=a1_0.account_type_id order by a2_0.type_name desc offset ? rows fetch first ? rows only
```

<details>
    <summary>Entity: AccountLazyAndExported.java</summary>

```java
package dev.mikoto2000.study.springboot.data.rest.example.entity;

import jakarta.persistence.Entity;
import jakarta.persistence.FetchType;
import jakarta.persistence.GeneratedValue;
import jakarta.persistence.GenerationType;
import jakarta.persistence.Id;
import jakarta.persistence.JoinColumn;
import jakarta.persistence.ManyToOne;
import jakarta.persistence.Table;
import lombok.Data;
import org.springframework.data.rest.core.annotation.RestResource;

@Data
@Entity
@Table(name = "account")
public class AccountLazyAndExported {

    @Id
    @GeneratedValue(strategy = GenerationType.AUTO)
    private Long id;

    private String name;

    @RestResource(exported = true)
    @JoinColumn(name = "account_type_id")
    @ManyToOne(fetch = FetchType.LAZY)
    private AccountType accountType;
}
```

</details>

<details>
    <summary>Repository: AccountLazyAndExportedRepository.java</summary>

```java
package dev.mikoto2000.study.springboot.data.rest.example.repository;

import org.springframework.data.jpa.repository.JpaRepository;
import org.springframework.data.rest.core.annotation.RepositoryRestResource;

import dev.mikoto2000.study.springboot.data.rest.example.entity.AccountLazyAndExported;

@RepositoryRestResource(collectionResourceRel = "accounts_lazy_and_exported", path = "accounts_lazy_and_exported")
public interface AccountLazyAndExportedRepository extends JpaRepository<AccountLazyAndExported, Long> {
    
}
```

</details>

</details>

<details>
    <summary><b>lazy and no exported</b></summary>

In the first place, it is not supported by Spring Data REST.

</details>

</details>



Example code repository: https://github.com/mikoto2000/spring-data-rest-example


- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
