### PR TITLE
Fix typos and annotation use in reference documentation

### DIFF
--- a/src/main/antora/modules/ROOT/pages/customizing/overriding-sdr-response-handlers.adoc
+++ b/src/main/antora/modules/ROOT/pages/customizing/overriding-sdr-response-handlers.adoc
@@ -93,7 +93,7 @@ In case you are using jMolecules, `AssociationAggregateReference` also allows yo
 While both of the abstraction assume the value for the parameter to be a URI matching the scheme that Spring Data REST uses to expose item resources, that source value resolution can be customized by calling `….withIdSource(…)` on the reference instance to provide a function to extract the identifier value to be used for aggregate resolution eventually from the `UriComponents` obtained from the URI received.
 
 [[customizing-sdr.overriding-sdr-response-handlers.annotations]]
-== `@RepositoryRestResource` VS. `@BasePathAwareController`
+== `@RepositoryRestController` VS. `@BasePathAwareController`
 
 If you are not interested in entity-specific operations but still want to build custom operations underneath `basePath`, such as Spring MVC views, resources, and others, use `@BasePathAwareController`.
 If you're using `@RepositoryRestController` on your custom controller, it will only handle the request if your request mappings blend into the URI space used by the repository.

--- a/src/main/antora/modules/ROOT/pages/customizing/overriding-sdr-response-handlers.adoc
+++ b/src/main/antora/modules/ROOT/pages/customizing/overriding-sdr-response-handlers.adoc
@@ -47,7 +47,7 @@ class ScannerController {
 
 `CollectionModel` is for a collection, while `EntityModel` -- or the more general class `RepresentationModel` -- is for a single item. These types can be combined. If you know the links for each item in a collection, use `CollectionModel<EntityModel<String>>` (or whatever the core domain type is rather than `String`). Doing so lets you assemble links for each item as well as for the whole collection.
 
-IMPORTANT: In this example, the combined path is `RepositoryRestConfiguration.getBasePath()` + `/scanners/search/listProducers`.
+IMPORTANT: In this example, the combined path is `RepositoryRestConfiguration.getBasePath()` + `/scanners/search/producers`.
 
 [[customizing-sdr.aggregate-references]]
 == Obtaining Aggregate References

--- a/src/main/antora/modules/ROOT/pages/customizing/overriding-sdr-response-handlers.adoc
+++ b/src/main/antora/modules/ROOT/pages/customizing/overriding-sdr-response-handlers.adoc
@@ -9,7 +9,7 @@ The following example shows how to use the `@RepositoryRestController` annotatio
 ====
 [source,java]
 ----
-@BasePathAwareController
+@RepositoryRestController
 class ScannerController {
 
   private final ScannerRepository repository;
@@ -60,7 +60,7 @@ All you need to do is declare an `@RequestParam` of that type and then consume e
 
 [source,java]
 ----
-@BasePathAwareController
+@RepositoryRestController
 class ScannerController {
 
   private final ScannerRepository repository;


### PR DESCRIPTION
1. Change the url in important note to `/scanners/search/producers`, so as to match the mapping path in `@GetMapping(path = "/scanners/search/producers")`

2. Change annotation `@BasePathAwareController` to `@RepositoryRestController` in the java code examples, because the text is talking about `@RepositoryRestController`.

3. Change the header `@RepositoryRestResource VS. @BasePathAwareController` to `@RepositoryRestController VS. @BasePathAwareController`, because the content is talking about `@RepositoryRestController`

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
