### PR TITLE
Fix DomainObjectReader merges for `@JsonAnySetter` properties

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/DomainObjectReader.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/DomainObjectReader.java
@@ -257,6 +257,12 @@ public class DomainObjectReader {
 			}
 
 			PersistentProperty<?> property = mappedProperties.getPersistentProperty(fieldName);
+			
+			// This means there's an @JsonAnySetter present for fieldName
+			if (property == null) {
+				continue;
+			}
+			
 			Optional<Object> rawValue = Optional.ofNullable(accessor.getProperty(property));
 
 			if (!rawValue.isPresent() || associationLinks.isLinkableAssociation(property)) {


### PR DESCRIPTION
Closes #2407
Related tickets #2407

See #2407 for a more detailed description.

The actual use case, in case anyone is interested is to be able to expose a `Map` where `null` values are possible. So we couldn't persist a `Map` because in our case hibernate doesn't let you use maps with null values (and only keys). So we used an embedded type in a `Set` and `JsonAnyGetter/Setter` to do the JSON handling.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
