### PR TITLE
Fix integer overflow in `@Order` of `RepositoryRelProvider`

### DIFF
--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/support/RepositoryRelProvider.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/support/RepositoryRelProvider.java
@@ -27,8 +27,9 @@ import org.springframework.util.Assert;
  * A {@link LinkRelationProvider} based on the {@link ResourceMappings} for the registered repositories.
  *
  * @author Oliver Gierke
+ * @author Andrey Litvitski
  */
-@Order(Ordered.LOWEST_PRECEDENCE + 10)
+@Order(Ordered.LOWEST_PRECEDENCE - 10)
 public class RepositoryRelProvider implements LinkRelationProvider {
 
 	private final ObjectFactory<ResourceMappings> mappings;


### PR DESCRIPTION
As @bgiddens wrote in #2477, it was probably assumed that we didn't want the lowest priority, that's why we subtract 10. However, if we plus, then a stack overflow is triggered and vice versa, the order is highest.

Fixes: #2477 