### PR TITLE
Corrected Access Modifier of configureJacksonObjectMapper

### DIFF
--- a/src/main/antora/modules/ROOT/pages/representations.adoc
+++ b/src/main/antora/modules/ROOT/pages/representations.adoc
@@ -36,7 +36,7 @@ To add your own Jackson configuration to the `ObjectMapper` used by Spring Data 
 [source,java]
 ----
 @Override
-protected void configureJacksonObjectMapper(ObjectMapper objectMapper) {
+public void configureJacksonObjectMapper(ObjectMapper objectMapper) {
 
   objectMapper.registerModule(new SimpleModule("MyCustomModule") {
 


### PR DESCRIPTION
`configureJacksonObjectMapper` cannot be `protected` because it overrides a `public` method from the [RepositoryRestConfigurer](https://docs.spring.io/spring-data/rest/docs/4.5.0/api/org/springframework/data/rest/webmvc/config/RepositoryRestConfigurer.html) interface.