### PR TITLE
Corrected method signature in customizing-sdr doc

### DIFF
--- a/src/main/antora/modules/ROOT/pages/customizing-sdr.adoc
+++ b/src/main/antora/modules/ROOT/pages/customizing-sdr.adoc
@@ -23,7 +23,7 @@ On Java 8, we can register the mapping methods as method references to tweak the
 public class SpringDataRestCustomization implements RepositoryRestConfigurer {
 
   @Override
-  public void configureRepositoryRestConfiguration(RepositoryRestConfiguration config) {
+  public void configureRepositoryRestConfiguration(RepositoryRestConfiguration config, CorsRegistry cors) {
     config.withEntityLookup()
       .forRepository(UserRepository.class)
       .withIdMapping(User::getUsername)


### PR DESCRIPTION
Updated the [method signature in customizing-sdr.adoc](https://github.com/spring-projects/spring-data-rest/blob/4.5.x/src/main/antora/modules/ROOT/pages/customizing-sdr.adoc#customizing-item-resource-uris) for accuracy.

The correct signature is: [configureRepositoryRestConfiguration(RepositoryRestConfiguration config, CorsRegistry cors)](https://docs.spring.io/spring-data/rest/docs/4.5.0/api/org/springframework/data/rest/webmvc/config/RepositoryRestConfigurer.html#configureRepositoryRestConfiguration(org.springframework.data.rest.core.config.RepositoryRestConfiguration,org.springframework.web.servlet.config.annotation.CorsRegistry)).