### PR TITLE
Fix parameter name typo in ExposureConfigurer

### DIFF
--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/mapping/ExposureConfigurer.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/mapping/ExposureConfigurer.java
@@ -33,7 +33,7 @@ public interface ExposureConfigurer {
 	 */
 	interface AggregateResourceHttpMethodsFilter extends ComposableFilter<ResourceMetadata, ConfigurableHttpMethods> {
 
-		ConfigurableHttpMethods filter(ResourceMetadata metdata, ConfigurableHttpMethods httpMethods);
+		ConfigurableHttpMethods filter(ResourceMetadata metadata, ConfigurableHttpMethods httpMethods);
 
 		/**
 		 * Returns a default filter that just returns all {@link HttpMethods} as is, i.e. does not apply any filtering.
@@ -53,7 +53,7 @@ public interface ExposureConfigurer {
 	interface AssociationResourceHttpMethodsFilter
 			extends ComposableFilter<PropertyAwareResourceMapping, ConfigurableHttpMethods> {
 
-		ConfigurableHttpMethods filter(PropertyAwareResourceMapping metdata, ConfigurableHttpMethods httpMethods);
+		ConfigurableHttpMethods filter(PropertyAwareResourceMapping metadata, ConfigurableHttpMethods httpMethods);
 
 		/**
 		 * Returns a default filter that just returns all {@link HttpMethods} as is, i.e. does not apply any filtering.


### PR DESCRIPTION
The parameter name `metdata` seems to be a typo?