### PR TITLE
Issue 2495: response handling for multi link request

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryPropertyReferenceController.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryPropertyReferenceController.java
@@ -291,8 +291,9 @@ class RepositoryPropertyReferenceController /*extends AbstractRepositoryRestCont
 				}
 
 				if (!source.getLinks().hasSingleLink()) {
-					throw new IllegalArgumentException(
-							"Must send only 1 link to update a property reference that isn't a List or a Map.");
+                    throw new HttpMessageNotReadableException(
+                            "Must send only 1 link to update a property reference that isn't a List or a Map.",
+                            InputStreamHttpInputMessage.of(InputStream.nullInputStream()));
 				}
 
 				prop.accessor.setProperty(prop.property,

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryPropertyReferenceController.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryPropertyReferenceController.java
@@ -269,6 +269,10 @@ class RepositoryPropertyReferenceController /*extends AbstractRepositoryRestCont
 				prop.accessor.setProperty(prop.property, collection);
 
 			} else if (prop.property.isMap()) {
+                if(source.getLinks().isEmpty()) {
+                    throw new HttpMessageNotReadableException("No links provided",
+                            InputStreamHttpInputMessage.of(InputStream.nullInputStream()));
+                }
 
 				Map<LinkRelation, Object> map = AUGMENTING_METHODS.contains(requestMethod) //
 						? (Map<LinkRelation, Object>) prop.propertyValue //

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryPropertyReferenceController.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryPropertyReferenceController.java
@@ -19,6 +19,8 @@ import static java.util.stream.Collectors.*;
 import static org.springframework.data.rest.webmvc.RestMediaTypes.*;
 import static org.springframework.web.bind.annotation.RequestMethod.*;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,6 +44,7 @@ import org.springframework.data.rest.core.event.AfterLinkSaveEvent;
 import org.springframework.data.rest.core.event.BeforeLinkDeleteEvent;
 import org.springframework.data.rest.core.event.BeforeLinkSaveEvent;
 import org.springframework.data.rest.webmvc.support.BackendId;
+import org.springframework.data.rest.webmvc.util.InputStreamHttpInputMessage;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.IanaLinkRelations;
@@ -54,6 +57,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -248,6 +252,10 @@ class RepositoryPropertyReferenceController /*extends AbstractRepositoryRestCont
 			Class<?> propertyType = prop.property.getType();
 
 			if (prop.property.isCollectionLike()) {
+                if(source.getLinks().isEmpty()) {
+                    throw new HttpMessageNotReadableException("No links provided",
+                            InputStreamHttpInputMessage.of(InputStream.nullInputStream()));
+                }
 
 				Collection<Object> collection = AUGMENTING_METHODS.contains(requestMethod) //
 						? (Collection<Object>) prop.propertyValue //

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/RepositoryPropertyReferenceControllerUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/RepositoryPropertyReferenceControllerUnitTests.java
@@ -141,6 +141,30 @@ class RepositoryPropertyReferenceControllerUnitTests {
                         "reference"));
     }
 
+    @Test // GH-2495
+    void rejectsMapLinksForSingleValuedAssociation() throws Exception {
+
+        KeyValuePersistentEntity<?, ?> entity = mappingContext.getRequiredPersistentEntity(MapSample.class);
+
+        ResourceMappings mappings = new PersistentEntitiesResourceMappings(
+                new PersistentEntities(Collections.singleton(mappingContext)));
+        ResourceMetadata metadata = spy(mappings.getMetadataFor(MapSample.class));
+        when(metadata.getSupportedHttpMethods()).thenReturn(AllSupportedHttpMethods.INSTANCE);
+
+        RepositoryPropertyReferenceController controller = new RepositoryPropertyReferenceController(repositories,
+                invokerFactory);
+        controller.setApplicationEventPublisher(publisher);
+
+        doReturn(Optional.of(new MapSample())).when(invoker).invokeFindById(4711);
+
+        RootResourceInformation information = new RootResourceInformation(metadata, entity, invoker);
+
+        //Do we need integration test to verify HTTP response code?
+        assertThatExceptionOfType(HttpMessageNotReadableException.class)
+                .isThrownBy(() -> controller.createPropertyReference(information, HttpMethod.POST, null, 4711,
+                        "reference"));
+    }
+
 
     @RestResource
 	static class Sample {
@@ -150,6 +174,11 @@ class RepositoryPropertyReferenceControllerUnitTests {
     @RestResource
     static class SingleSample {
         @org.springframework.data.annotation.Reference Reference reference;
+    }
+
+    @RestResource
+    static class MapSample {
+        @org.springframework.data.annotation.Reference Map<Reference, Reference> reference;
     }
 
 	@RestResource

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/RepositoryPropertyReferenceControllerUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/RepositoryPropertyReferenceControllerUnitTests.java
@@ -19,10 +19,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -113,9 +110,35 @@ class RepositoryPropertyReferenceControllerUnitTests {
 
         RootResourceInformation information = new RootResourceInformation(metadata, entity, invoker);
 
+        //Do we need integration test to verify HTTP response code?
         assertThatExceptionOfType(HttpMessageNotReadableException.class)
                 .isThrownBy(() -> controller.createPropertyReference(information, HttpMethod.POST, null,  4711,
                         "references"));
+    }
+
+    @Test // GH-2495
+    void rejectsMultipleLinksForSingleValuedAssociation() throws Exception {
+
+        KeyValuePersistentEntity<?, ?> entity = mappingContext.getRequiredPersistentEntity(SingleSample.class);
+
+        ResourceMappings mappings = new PersistentEntitiesResourceMappings(
+                new PersistentEntities(Collections.singleton(mappingContext)));
+        ResourceMetadata metadata = spy(mappings.getMetadataFor(SingleSample.class));
+        when(metadata.getSupportedHttpMethods()).thenReturn(AllSupportedHttpMethods.INSTANCE);
+
+        RepositoryPropertyReferenceController controller = new RepositoryPropertyReferenceController(repositories,
+                invokerFactory);
+        controller.setApplicationEventPublisher(publisher);
+
+        doReturn(Optional.of(new SingleSample())).when(invoker).invokeFindById(4711);
+
+        RootResourceInformation information = new RootResourceInformation(metadata, entity, invoker);
+        CollectionModel<Object> request = CollectionModel.empty(List.of(Link.of("/reference/1"), Link.of("/reference/2")));
+
+        //Do we need integration test to verify HTTP response code?
+        assertThatExceptionOfType(HttpMessageNotReadableException.class)
+                .isThrownBy(() -> controller.createPropertyReference(information, HttpMethod.POST, request, 4711,
+                        "reference"));
     }
 
 
@@ -123,6 +146,11 @@ class RepositoryPropertyReferenceControllerUnitTests {
 	static class Sample {
 		@org.springframework.data.annotation.Reference List<Reference> references = new ArrayList<Reference>();
 	}
+
+    @RestResource
+    static class SingleSample {
+        @org.springframework.data.annotation.Reference Reference reference;
+    }
 
 	@RestResource
 	static class Reference {}


### PR DESCRIPTION
This PR is to solve [issue 2495](https://github.com/spring-projects/spring-data-rest/issues/2495).

It handles correction of error codes for single association resource. However, it doesn't (yet) handles multiple association resource.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
