### PR TITLE
Return 400 Bad Request when request body converter returns incompatible type

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/PersistentEntityResourceHandlerMethodArgumentResolver.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/PersistentEntityResourceHandlerMethodArgumentResolver.java
@@ -63,6 +63,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
  * @author Jon Brisbin
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Babalola Opeyemi Daniel
  */
 public class PersistentEntityResourceHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver {
 
@@ -136,6 +137,10 @@ public class PersistentEntityResourceHandlerMethodArgumentResolver implements Ha
 			Object newObject = read(resourceInformation, incoming, converter, objectToUpdate);
 
 			if (newObject == null) {
+				throw new HttpMessageNotReadableException(String.format(ERROR_MESSAGE, domainType), request);
+			}
+
+			if (!domainType.isInstance(newObject)) {
 				throw new HttpMessageNotReadableException(String.format(ERROR_MESSAGE, domainType), request);
 			}
 

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/config/PersistentEntityResourceHandlerMethodArgumentResolverUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/config/PersistentEntityResourceHandlerMethodArgumentResolverUnitTests.java
@@ -42,7 +42,9 @@ import org.springframework.data.rest.webmvc.json.patch.TestPropertyPathContext;
 import org.springframework.data.rest.webmvc.support.BackendIdHandlerMethodArgumentResolver;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.MediaType;
+import org.springframework.hateoas.CollectionModel;
 import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.plugin.core.PluginRegistry;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -55,6 +57,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
  * Unit tests for {@link PersistentEntityResourceHandlerMethodArgumentResolver}.
  *
  * @author Oliver Gierke
+ * @author Babalola Opeyemi Daniel
  */
 class PersistentEntityResourceHandlerMethodArgumentResolverUnitTests {
 
@@ -121,6 +124,23 @@ class PersistentEntityResourceHandlerMethodArgumentResolverUnitTests {
 			assertThat(it.getContent()).isInstanceOfSatisfying(Foo.class, foo -> {
 				assertThat(foo.name).isEqualTo("someName");
 			});
+		});
+	}
+
+	@Test // GH-1194
+	@SuppressWarnings("unchecked")
+	void rejectsRequestBodyIfConverterReturnsIncompatibleType() throws Exception {
+
+		PersistentEntityResourceHandlerMethodArgumentResolver argumentResolver = new PersistentEntityResourceHandlerMethodArgumentResolver(
+				Arrays.<HttpMessageConverter<?>> asList(converter), rootResourceResolver, backendIdResolver, reader,
+				PluginRegistry.empty(), FACTORY);
+
+		HttpServletRequest request = new MockHttpServletRequest("POST", "/foo");
+
+		doReturn(CollectionModel.empty()).when(converter).read(Mockito.any(Class.class), Mockito.any(HttpInputMessage.class));
+
+		assertThatExceptionOfType(HttpMessageNotReadableException.class).isThrownBy(() -> {
+			argumentResolver.resolveArgument(null, null, new ServletWebRequest(request), null);
 		});
 	}
 


### PR DESCRIPTION
Fixes #1194.
|
When `text/uri-list` is posted to a non-association endpoint, `UriListHttpMessageConverter` returns a `CollectionModel` of links. The argument resolver then fails with an internal exception mapped to 500.
This change validates the converter output type and throws `HttpMessageNotReadableException` (400) instead.
- Added type check in `PersistentEntityResourceHandlerMethodArgumentResolver`
- Added unit test `rejectsRequestBodyIfConverterReturnsIncompatibleType`
---

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).