### PR TITLE
Consider nested property paths when filtering Querydsl parameters.

### DIFF
--- a/spring-data-rest-tests/spring-data-rest-tests-mongodb/src/test/java/org/springframework/data/rest/webmvc/config/QuerydslAwareRootResourceInformationHandlerMethodArgumentResolverUnitTests.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-mongodb/src/test/java/org/springframework/data/rest/webmvc/config/QuerydslAwareRootResourceInformationHandlerMethodArgumentResolverUnitTests.java
@@ -64,6 +64,7 @@ import com.querydsl.core.types.Predicate;
  * Unit tests for {@link QuerydslAwareRootResourceInformationHandlerMethodArgumentResolver}.
  *
  * @author Oliver Gierke
+ * @author Lovro Vrlec
  */
 @ExtendWith(MockitoExtension.class)
 class QuerydslAwareRootResourceInformationHandlerMethodArgumentResolverUnitTests {
@@ -178,6 +179,42 @@ class QuerydslAwareRootResourceInformationHandlerMethodArgumentResolverUnitTests
 		MultiValueMap<String, String> forwarded = captor.getValue();
 		assertThat(forwarded).doesNotContainKey("renamed");
 		assertThat(forwarded.get("aliased")).containsExactly("value");
+	}
+
+	@Test // GH-2579
+	void forwardsNestedPropertyPathsToQuerydsl() {
+
+		Object repository = mock(QuerydslUserRepository.class);
+		when(repositories.getRepositoryFor(User.class)).thenReturn(Optional.of(repository));
+
+		Map<String, String[]> parameters = Map.of("address.street", new String[] { "value" });
+
+		ArgumentCaptor<MultiValueMap<String, String>> captor = ArgumentCaptor.captor();
+		when(builder.getPredicate(any(), captor.capture(), any())).thenReturn(mock(Predicate.class));
+
+		resolver.postProcess(parameter, invoker, User.class, parameters);
+
+		// Neither User.address nor Address.street is hidden from serialization, so the nested path has to reach Querydsl,
+		// which resolves dotted paths itself. Dropping it would silently turn a filtered lookup into an unfiltered one.
+		assertThat(captor.getValue().get("address.street")).containsExactly("value");
+	}
+
+	@Test // GH-2579
+	void doesNotExposeJsonIgnoredPropertiesNestedInAssociations() {
+
+		Object repository = mock(QuerydslUserRepository.class);
+		when(repositories.getRepositoryFor(User.class)).thenReturn(Optional.of(repository));
+
+		Map<String, String[]> parameters = Map.of("manager.ignored", new String[] { "candidate-value" });
+
+		ArgumentCaptor<MultiValueMap<String, String>> captor = ArgumentCaptor.captor();
+		when(builder.getPredicate(any(), captor.capture(), any())).thenReturn(mock(Predicate.class));
+
+		resolver.postProcess(parameter, invoker, User.class, parameters);
+
+		// User.manager is visible, but User.ignored is @JsonIgnore-annotated: the guarantee established for top-level
+		// properties has to hold for every segment of a nested path as well.
+		assertThat(captor.getValue()).doesNotContainKey("manager.ignored");
 	}
 
 	interface QuerydslUserRepository extends QuerydslPredicateExecutor<User> {}

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/QuerydslAwareRootResourceInformationHandlerMethodArgumentResolver.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/QuerydslAwareRootResourceInformationHandlerMethodArgumentResolver.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 
 import org.jspecify.annotations.Nullable;
 
@@ -51,10 +52,13 @@ import com.querydsl.core.types.Predicate;
  *
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Lovro Vrlec
  * @since 2.4
  */
 class QuerydslAwareRootResourceInformationHandlerMethodArgumentResolver
 		extends RootResourceInformationHandlerMethodArgumentResolver {
+
+	private static final Pattern NESTED_PATH_SEPARATOR = Pattern.compile("\\.");
 
 	private final Repositories repositories;
 	private final QuerydslPredicateBuilder predicateBuilder;
@@ -123,9 +127,7 @@ class QuerydslAwareRootResourceInformationHandlerMethodArgumentResolver
 	 */
 	private Map<String, String[]> filterByJacksonVisibility(Class<?> domainType, Map<String, String[]> parameters) {
 
-		MappedJacksonProperties properties = jacksonPropertiesLookup.apply(domainType);
-
-		if (properties == null) {
+		if (jacksonPropertiesLookup.apply(domainType) == null) {
 			return parameters;
 		}
 
@@ -133,14 +135,51 @@ class QuerydslAwareRootResourceInformationHandlerMethodArgumentResolver
 
 		for (Entry<String, String[]> entry : parameters.entrySet()) {
 
-			PersistentProperty<?> property = properties.getPersistentProperty(entry.getKey());
+			String path = resolvePath(domainType, entry.getKey());
 
-			if (property != null) {
-				filtered.put(property.getName(), entry.getValue());
+			if (path != null) {
+				filtered.put(path, entry.getValue());
 			}
 		}
 
 		return filtered;
+	}
+
+	/**
+	 * Resolves the given request parameter name into the property path Querydsl operates on, applying the visibility
+	 * rules of {@link #filterByJacksonVisibility(Class, Map)} to every segment of a nested path, as Querydsl supports
+	 * filtering on nested properties (e.g. {@code address.street}). Returns {@literal null} if a segment does not refer
+	 * to a property Jackson exposes, so that a hidden property cannot be reached through an association either, or if
+	 * the type owning a segment is not backed by a {@link MappedJacksonProperties} instance, in which case visibility
+	 * cannot be established.
+	 *
+	 * @param domainType the type the leading segment is resolved against, must not be {@literal null}.
+	 * @param parameterName must not be {@literal null}.
+	 * @return the translated property path or {@literal null} if the parameter must not be forwarded to Querydsl.
+	 */
+	private @Nullable String resolvePath(Class<?> domainType, String parameterName) {
+
+		StringBuilder path = new StringBuilder(parameterName.length());
+		Class<?> owningType = domainType;
+
+		for (String segment : NESTED_PATH_SEPARATOR.split(parameterName)) {
+
+			MappedJacksonProperties properties = jacksonPropertiesLookup.apply(owningType);
+			PersistentProperty<?> property = properties == null ? null : properties.getPersistentProperty(segment);
+
+			if (property == null) {
+				return null;
+			}
+
+			if (!path.isEmpty()) {
+				path.append('.');
+			}
+
+			path.append(property.getName());
+			owningType = property.getActualType();
+		}
+
+		return path.toString();
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Fixes the regression reported in #2579.

Since GH-2572, `filterByJacksonVisibility` matches each request parameter against a flat map of
top-level Jackson field names. A nested key such as `address.street` is never a key in that map, so
it is dropped and the endpoint silently degrades to `findAll` — a filtered request returns every row.
Nested paths are otherwise fully supported: `QuerydslPredicateBuilder` resolves them via
`bindings.getPropertyPath(...)`, and they worked up to 5.0.5.

This resolves parameter names segment by segment, translating each segment through its own
`MappedJacksonProperties` so `@JsonProperty` renames keep working at depth, and rejecting the whole
parameter as soon as a segment is not exposed — extending the GH-2572 guarantee to nested paths
instead of weakening it.

Two tests, added in the first commit so the regression is visible on its own:
- `forwardsNestedPropertyPathsToQuerydsl` fails before the fix (the parameter never reaches Querydsl).
- `doesNotExposeJsonIgnoredPropertiesNestedInAssociations` passes before the fix only vacuously, and
  fails against a naive fix that forwards dotted keys unchecked — it pins the security property.

One deliberate decision worth your input: when a segment's owning type has no `MappedJacksonProperties`
(e.g. a map value), visibility cannot be established, so the parameter is rejected. This is stricter
than pre-5.0.5 behaviour, where such paths were forwarded and left to Querydsl's binding resolution to
reject. Happy to switch to forwarding them if you prefer the lenient variant.