### PR TITLE
Fix broken HATEOAS link in repository-resources.adoc

### DIFF
--- a/src/main/antora/modules/ROOT/pages/repository-resources.adoc
+++ b/src/main/antora/modules/ROOT/pages/repository-resources.adoc
@@ -44,7 +44,7 @@ Read more on this in the detailed description of xref:repository-resources.adoc#
 [[repository-resources.resource-discoverability]]
 === Resource Discoverability
 
-A core principle of https://github.com/spring-guides/understanding/tree/master/hateoas[HATEOAS] is that resources should be discoverable through the publication of links that point to the available resources. There are a few competing de-facto standards of how to represent links in JSON. By default, Spring Data REST uses https://tools.ietf.org/html/draft-kelly-json-hal[HAL] to render responses. HAL defines the links to be contained in a property of the returned document.
+A core principle of https://github.com/spring-attic/understanding/blob/master/hateoas/README.md[HATEOAS] is that resources should be discoverable through the publication of links that point to the available resources. There are a few competing de-facto standards of how to represent links in JSON. By default, Spring Data REST uses https://tools.ietf.org/html/draft-kelly-json-hal[HAL] to render responses. HAL defines the links to be contained in a property of the returned document.
 
 Resource discovery starts at the top level of the application. By issuing a request to the root URL under which the Spring Data REST application is deployed, the client can extract, from the returned JSON object, a set of links that represent the next level of resources that are available to the client.
 


### PR DESCRIPTION
The HATEOAS reference in the "Resource Discoverability" section linked to a tree view of `spring-guides/understanding/hateoas`. That repository has since been archived and moved to `spring-attic/understanding`, and the directory is no longer published as a rendered guide (it's just a source folder containing a `README.md`).

This updates the link to point directly at the `README.md` file in the current `spring-attic/understanding` location, so it renders correctly on GitHub.

Closes gh-1751.