### PR TITLE
Added support for `If-None-Match: *` with PUT requests

### DIFF
--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/RepositoryEntityControllerIntegrationTests.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/RepositoryEntityControllerIntegrationTests.java
@@ -63,6 +63,7 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
  *
  * @author Oliver Gierke
  * @author Jeremy Rickard
+ * @author Steve Rutherford
  */
 @ContextConfiguration(classes = { ConfigurationCustomizer.class, JpaRepositoryConfig.class })
 @Transactional

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/RepositoryEntityControllerIntegrationTests.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/RepositoryEntityControllerIntegrationTests.java
@@ -47,6 +47,7 @@ import org.springframework.data.rest.webmvc.jpa.Order;
 import org.springframework.data.rest.webmvc.jpa.Person;
 import org.springframework.data.rest.webmvc.support.DefaultedPageable;
 import org.springframework.data.rest.webmvc.support.ETag;
+import org.springframework.data.rest.webmvc.support.ETagDoesntMatchException;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -114,7 +115,7 @@ class RepositoryEntityControllerIntegrationTests extends AbstractControllerInteg
 				.build(new Order(new Person()), entities.getRequiredPersistentEntity(Order.class)).build();
 
 		ResponseEntity<?> entity = controller.putItemResource(information, persistentEntityResource, 1L, assembler,
-				ETag.NO_ETAG, MediaType.APPLICATION_JSON_VALUE);
+				ETag.NO_ETAG, new HttpHeaders(), MediaType.APPLICATION_JSON_VALUE);
 
 		assertThat(entity.getHeaders().getLocation().toString()).doesNotEndWith("{?projection}");
 	}
@@ -198,7 +199,7 @@ class RepositoryEntityControllerIntegrationTests extends AbstractControllerInteg
 				.build(new Order(new Person()), entities.getRequiredPersistentEntity(Order.class)).build();
 
 		assertThat(controller.putItemResource(request, persistentEntityResource, order.getId(), assembler, ETag.NO_ETAG,
-				MediaType.APPLICATION_JSON_VALUE).hasBody()).isTrue();
+				new HttpHeaders(), MediaType.APPLICATION_JSON_VALUE).hasBody()).isTrue();
 	}
 
 	@Test // DATAREST-34
@@ -209,7 +210,7 @@ class RepositoryEntityControllerIntegrationTests extends AbstractControllerInteg
 				.build(new Order(new Person()), entities.getRequiredPersistentEntity(Order.class)).forCreation();
 
 		assertThat(controller.putItemResource(request, persistentEntityResource, 1L, assembler, ETag.NO_ETAG,
-				MediaType.APPLICATION_JSON_VALUE).hasBody()).isTrue();
+				new HttpHeaders(), MediaType.APPLICATION_JSON_VALUE).hasBody()).isTrue();
 	}
 
 	@Test // DATAREST-34
@@ -283,7 +284,40 @@ class RepositoryEntityControllerIntegrationTests extends AbstractControllerInteg
 
 		assertThatExceptionOfType(HttpRequestMethodNotSupportedException.class) //
 				.isThrownBy(() -> controller.putItemResource(request, persistentEntityResource, 1L, assembler, ETag.NO_ETAG,
-						MediaType.APPLICATION_JSON_VALUE));
+						new HttpHeaders(), MediaType.APPLICATION_JSON_VALUE));
+	}
+
+	@Test // GH-xxxx
+	void putWithIfNoneMatchWildcardSucceedsWhenResourceDoesNotExist() throws HttpRequestMethodNotSupportedException {
+
+		RootResourceInformation request = getResourceInformation(Order.class);
+		PersistentEntityResource persistentEntityResource = PersistentEntityResource
+				.build(new Order(new Person()), entities.getRequiredPersistentEntity(Order.class)).forCreation();
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.setIfNoneMatch("*");
+
+		ResponseEntity<?> response = controller.putItemResource(request, persistentEntityResource, 999L, assembler,
+				ETag.NO_ETAG, headers, MediaType.APPLICATION_JSON_VALUE);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+	}
+
+	@Test // GH-xxxx
+	void putWithIfNoneMatchWildcardFailsWhenResourceAlreadyExists() throws Exception {
+
+		RootResourceInformation request = getResourceInformation(Order.class);
+		Order order = request.getInvoker().invokeSave(new Order(new Person()));
+
+		PersistentEntityResource persistentEntityResource = PersistentEntityResource
+				.build(new Order(new Person()), entities.getRequiredPersistentEntity(Order.class)).build();
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.setIfNoneMatch("*");
+
+		assertThatExceptionOfType(ETagDoesntMatchException.class) //
+				.isThrownBy(() -> controller.putItemResource(request, persistentEntityResource, order.getId(), assembler,
+						ETag.NO_ETAG, headers, MediaType.APPLICATION_JSON_VALUE));
 	}
 
 	@TestFactory // #2225

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryEntityController.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryEntityController.java
@@ -73,6 +73,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
  * @author Greg Turnquist
  * @author Jeremy Rickard
  * @author Jeroen Reijn
+ * @author Steve Rutherford
  */
 @RepositoryRestController
 class RepositoryEntityController

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryEntityController.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryEntityController.java
@@ -334,6 +334,7 @@ class RepositoryEntityController
 	 * @param id
 	 * @param assembler
 	 * @param eTag
+	 * @param requestHeaders
 	 * @param acceptHeader
 	 * @return
 	 * @throws HttpRequestMethodNotSupportedException
@@ -341,7 +342,8 @@ class RepositoryEntityController
 	@RequestMapping(value = BASE_MAPPING + "/{id}", method = RequestMethod.PUT)
 	public ResponseEntity<? extends RepresentationModel<?>> putItemResource(RootResourceInformation resourceInformation,
 			PersistentEntityResource payload, @BackendId Serializable id, PersistentEntityResourceAssembler assembler,
-			ETag eTag, @RequestHeader(value = ACCEPT_HEADER, required = false) String acceptHeader)
+			ETag eTag, @RequestHeader HttpHeaders requestHeaders,
+			@RequestHeader(value = ACCEPT_HEADER, required = false) String acceptHeader)
 			throws HttpRequestMethodNotSupportedException {
 
 		resourceInformation.verifySupportedMethod(HttpMethod.PUT, ResourceType.ITEM);
@@ -356,6 +358,13 @@ class RepositoryEntityController
 
 		if (objectToSave == null) {
 			throw new IllegalStateException("Payload content must not be null");
+		}
+
+		// Enforce If-None-Match: * — only allow the operation if the resource does not already exist (RFC 7232 §3.2)
+		List<String> ifNoneMatch = requestHeaders.getIfNoneMatch();
+		if (!ifNoneMatch.isEmpty() && "*".equals(ifNoneMatch.get(0))) {
+			Object existingObject = invoker.invokeFindById(id).orElse(null);
+			ETag.WILDCARD_ETAG.verifyNoneMatch(resourceInformation.getPersistentEntity(), existingObject);
 		}
 
 		return payload.isNew()

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/support/ETag.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/support/ETag.java
@@ -37,6 +37,7 @@ import org.springframework.util.Assert;
 public final class ETag {
 
 	public static final ETag NO_ETAG = new ETag(null);
+	public static final ETag WILDCARD_ETAG = new ETag("*");
 
 	private final @Nullable String value;
 
@@ -104,6 +105,23 @@ public final class ETag {
 		}
 
 		if (!this.equals(from(entity, target))) {
+			throw new ETagDoesntMatchException(target, this);
+		}
+	}
+
+	/**
+	 * Verifies that the given target does not exist when this {@link ETag} is a wildcard ({@code *}), raising an
+	 * {@link ETagDoesntMatchException} if the resource already exists. This implements the {@code If-None-Match: *}
+	 * semantics for {@code PUT} requests as defined in RFC 7232 §3.2: the operation should only proceed if the target
+	 * resource does not currently exist.
+	 *
+	 * @param entity must not be {@literal null}.
+	 * @param target the existing domain object, or {@literal null} if the resource does not exist.
+	 * @throws ETagDoesntMatchException if this is a wildcard ETag and the target already exists.
+	 */
+	public void verifyNoneMatch(PersistentEntity<?, ?> entity, @Nullable Object target) {
+
+		if (this == WILDCARD_ETAG && target != null) {
 			throw new ETagDoesntMatchException(target, this);
 		}
 	}

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/support/ETag.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/support/ETag.java
@@ -33,6 +33,7 @@ import org.springframework.util.Assert;
  *
  * @author Oliver Gierke
  * @author Dario Seidl
+ * @author Steve Rutherford
  */
 public final class ETag {
 

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/support/ETagUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/support/ETagUnitTests.java
@@ -31,6 +31,7 @@ import org.springframework.http.HttpHeaders;
  *
  * @author Pablo Lozano
  * @author Oliver Gierke
+ * @author Steve Rutherford
  */
 @ExtendWith(MockitoExtension.class)
 class ETagUnitTests {

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/support/ETagUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/support/ETagUnitTests.java
@@ -138,6 +138,29 @@ class ETagUnitTests {
 		assertThat(headers.getFirst("ETag")).isNull();
 	}
 
+	@Test // GH-xxxx
+	void wildcardETagVerifyNoneMatchThrowsWhenResourceExists() {
+
+		assertThatExceptionOfType(ETagDoesntMatchException.class) //
+				.isThrownBy(() -> ETag.WILDCARD_ETAG.verifyNoneMatch(context.getRequiredPersistentEntity(Sample.class),
+						new Sample(0L)));
+	}
+
+	@Test // GH-xxxx
+	void wildcardETagVerifyNoneMatchSucceedsWhenResourceDoesNotExist() {
+		ETag.WILDCARD_ETAG.verifyNoneMatch(context.getRequiredPersistentEntity(Sample.class), null);
+	}
+
+	@Test // GH-xxxx
+	void noETagVerifyNoneMatchDoesNotRejectExistingResource() {
+		ETag.NO_ETAG.verifyNoneMatch(context.getRequiredPersistentEntity(Sample.class), new Sample(0L));
+	}
+
+	@Test // GH-xxxx
+	void wildcardETagFromStringIsRecognized() {
+		assertThat(ETag.from("*")).isEqualTo(ETag.WILDCARD_ETAG);
+	}
+
 	// tag::versioned-sample[]
 	class Sample {
 

--- a/src/main/antora/modules/ROOT/pages/etags-and-other-conditionals.adoc
+++ b/src/main/antora/modules/ROOT/pages/etags-and-other-conditionals.adoc
@@ -44,6 +44,20 @@ curl -v -H 'If-None-Match: <value of previous etag>' ...
 
 The preceding command (by default) runs a `GET`. Spring Data REST checks for `If-None-Match` headers while doing a `GET`. If the header matches the ETag, it concludes that nothing has changed and, instead of sending a copy of the resource, sends back an HTTP `304 Not Modified` status code. Semantically, it reads "`If this supplied header value does not match the server-side version, send the whole resource. Otherwise, do not send anything.`"
 
+[[conditional.if-none-match-wildcard]]
+=== `If-None-Match: *` with `PUT`
+
+The special wildcard value `*` for `If-None-Match` can be used with a `PUT` request to ensure the operation only succeeds if the target resource does **not** already exist (as defined in https://tools.ietf.org/html/rfc7232#section-3.2[RFC 7232 §3.2]). This is useful for safe resource creation at a known URI without accidentally overwriting an existing resource.
+
+====
+----
+curl -v -X PUT -H 'If-None-Match: *' -H 'Content-Type: application/json' \
+     -d '{ ... }' http://localhost:8080/orders/42
+----
+====
+
+If the resource at the given URI does not yet exist, the `PUT` proceeds and creates it (returning `201 Created`). If the resource already exists, Spring Data REST returns `412 Precondition Failed`, preventing an unintended overwrite.
+
 NOTE: This POJO is from an `ETag`-based unit test, so it does not have `@Entity` (JPA) or `@Document` (MongoDB) annotations, as expected in application code. It focuses solely on how a field with `@Version` results in an `ETag` header.
 
 [[conditional.if-modified-since]]


### PR DESCRIPTION
Fixes [#1190](https://github.com/spring-projects/spring-data-rest/issues/1190)

## Overview
Added support for `If-None-Match: *` with PUT requests, implementing RFC 7232 §3.2 semantics (create-only guard). The following files were changed:

- `ETag.java`: — Added `WILDCARD_ETAG` constant (representing `*`) and a new `verifyNoneMatch(PersistentEntity, Object)` method that throws `ETagDoesntMatchException` when the ETag is a wildcard and the target resource already exists.

- `RepositoryEntityController.java`: — Added a `@RequestHeader HttpHeaders requestHeaders` parameter to `putItemResource`. When `If-None-Match: *` is present, the handler looks up the existing resource by ID and calls `ETag.WILDCARD_ETAG.verifyNoneMatch(...)` — if the resource exists, a `412 Precondition Failed` is returned (via the existing `ETagDoesntMatchException` handler); if it doesn't exist, the PUT proceeds normally as a creation.

- `ETagUnitTests.java`: — Added 4 unit tests covering: wildcard throws when resource exists, wildcard passes when resource is null, `NO_ETAG` never rejects, and `ETag.from("*")` equals `WILDCARD_ETAG`.

- `RepositoryEntityControllerIntegrationTests.java`: — Updated all existing `putItemResource` calls to pass the new `HttpHeaders` parameter, and added 2 new integration tests: one verifying a PUT with `If-None-Match: *` succeeds (201) when the resource doesn't exist, and one verifying it fails with `ETagDoesntMatchException` when the resource already exists.

- `etags-and-other-conditionals.adoc`: — Added a new `If-None-Match: *` with PUT subsection explaining the create-only guard semantics with a curl example.

---

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
