### PR TITLE
Fixed issue where JSONView does not work with @RepositoryRestController

### DIFF
--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/Person.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/Person.java
@@ -33,11 +33,13 @@ import org.springframework.data.rest.core.annotation.Description;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonView;
 
 /**
  * An entity that represents a person.
  *
  * @author Jon Brisbin
+ * @author Steve Rutherford
  */
 @Entity
 @JsonIgnoreProperties({ "height", "weight" })
@@ -46,9 +48,11 @@ public class Person {
 	@Id @GeneratedValue private Long id;
 
 	@Description("A person's first name") //
+	@JsonView(PersonViews.Summary.class)
 	private String firstName;
 
 	@Description("A person's last name") //
+	@JsonView(PersonViews.Summary.class)
 	private String lastName;
 
 	@Description("A person's siblings") //

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaWebTests.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaWebTests.java
@@ -74,6 +74,7 @@ import com.jayway.jsonpath.ReadContext;
  * @author Mark Paluch
  * @author Ľubomír Varga
  * @author Dario Seidl
+ * @author Steve Rutherford
  */
 @Transactional
 @ContextConfiguration(classes = JpaRepositoryConfig.class, initializers = JpaWebTests.JpaContextInitializer.class)
@@ -96,6 +97,7 @@ public class JpaWebTests extends CommonWebTests {
 			ctx.registerBean(AuthorsController.class);
 			ctx.registerBean(BooksHtmlController.class);
 			ctx.registerBean(OrdersJsonController.class);
+			ctx.registerBean(PersonSummaryController.class);
 			ctx.registerBean(RepositoryLinkAffordanceAdder.class);
 		}
 	}
@@ -752,6 +754,22 @@ public class JpaWebTests extends CommonWebTests {
 		mvc.perform(get("/authors/42"));
 
 		assertThat(observationContext.getPathPattern()).isEqualTo("/authors/{id}");
+	}
+
+	@Test // DATAREST-891
+	void honorsJsonViewOnRepositoryRestControllerMethod() throws Exception {
+
+		// The summary endpoint uses @JsonView(PersonViews.Summary.class), which only includes
+		// firstName and lastName. Fields like 'gender', 'created', 'siblings', and 'father'
+		// must be absent from the response because they are not annotated with @JsonView(Summary).
+		mockMvc.perform(get("/people/summary").accept(MediaType.APPLICATION_JSON)) //
+				.andExpect(status().isOk()) //
+				.andExpect(jsonPath("$[0].firstName").exists()) //
+				.andExpect(jsonPath("$[0].lastName").exists()) //
+				.andExpect(jsonPath("$[0].gender").doesNotExist()) //
+				.andExpect(jsonPath("$[0].created").doesNotExist()) //
+				.andExpect(jsonPath("$[0].siblings").doesNotExist()) //
+				.andExpect(jsonPath("$[0].father").doesNotExist());
 	}
 
 	private List<Link> preparePersonResources(Person primary, Person... persons) throws Exception {

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
@@ -146,6 +146,7 @@ import org.springframework.web.servlet.HandlerExceptionResolver;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver;
+import org.springframework.web.servlet.mvc.method.annotation.JsonViewResponseBodyAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 import org.springframework.web.util.pattern.PathPatternParser;
@@ -163,6 +164,7 @@ import org.springframework.web.util.pattern.PathPatternParser;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author Will Fleury
+ * @author Steve Rutherford
  */
 @Configuration(proxyBeanMethods = false)
 @EnableHypermediaSupport(type = { HypermediaType.HAL, HypermediaType.HAL_FORMS })
@@ -658,6 +660,7 @@ public class RepositoryRestMvcConfiguration extends HateoasAwareSpringDataWebCon
 
 		List<ResponseBodyAdvice<?>> advices = new ArrayList<>();
 		advices.add(new HalFormsAdaptingResponseBodyAdvice<>());
+		advices.add(new JsonViewResponseBodyAdvice());
 
 		if (repositoryRestConfiguration.getMetadataConfiguration().alpsEnabled()) {
 			advices.addAll(Arrays.asList(alpsJsonHttpMessageConverter));


### PR DESCRIPTION
Fixes [#1260](https://github.com/spring-projects/spring-data-rest/issues/1260)

## Summary

**Issue:** [spring-data-rest#1161 / DATAREST-891](https://github.com/spring-projects/spring-data-rest/issues/1161) — `@JsonView` annotations on `@RepositoryRestController` methods were silently ignored, causing all fields to be serialized regardless of the view constraint.

**Root Cause:** Spring MVC's `JsonViewResponseBodyAdvice` was not registered in the `RepositoryRestHandlerAdapter` (the custom `RequestMappingHandlerAdapter` used by Spring Data REST). Without it, the `@JsonView` hint set by `RequestResponseBodyMethodProcessor` was never picked up during response serialization.

### Changes Made

**1. Core Fix — `RepositoryRestMvcConfiguration.java`**
- Added `import org.springframework.web.servlet.mvc.method.annotation.JsonViewResponseBodyAdvice`
- Registered `new JsonViewResponseBodyAdvice()` in the `ResponseBodyAdvice` list of `repositoryExporterHandlerAdapter()`

**2. Test Infrastructure — new files in `spring-data-rest-tests-jpa`**
- **`PersonViews.java`** — Jackson `@JsonView` marker interfaces (`Summary` and `Full`) for `Person`
- **`PersonSummaryController.java`** — A `@RepositoryRestController` with a `GET /people/summary` endpoint annotated with `@JsonView(PersonViews.Summary.class)`, demonstrating the fix
- **`Person.java`** — Added `@JsonView(PersonViews.Summary.class)` to `firstName` and `lastName` fields

**3. Test — `JpaWebTests.java`**
- Registered `PersonSummaryController` in `JpaContextInitializer`
- Added `honorsJsonViewOnRepositoryRestControllerMethod()` test that verifies `firstName`/`lastName` are present and `gender`/`created`/`siblings`/`father` are absent from the summary view response

The new test (`Tests run: 1, Failures: 0, Errors: 0`) confirms the fix works correctly.

---

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
