### PR TITLE
Replace linkable associations when merging existing array elements for merge patch

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/DomainObjectReader.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/DomainObjectReader.java
@@ -65,6 +65,7 @@ import org.springframework.util.ObjectUtils;
  * @author Mathias Düsterhöft
  * @author Thomas Mrozinski
  * @author Lars Vierbergen
+ * @author Takeshi Ogawa
  * @since 2.2
  */
 @SuppressWarnings("NullAway")
@@ -161,6 +162,38 @@ public class DomainObjectReader {
 	 */
 	@Nullable
 	<T> T mergeForPut(T source, T target, final ObjectMapper mapper) {
+		return mergeForPut(source, target, mapper, false);
+	}
+
+	/**
+	 * Reads the given {@link ObjectNode} into a new instance of the given existing array element's type and merges it
+	 * into the existing element applying {@literal PUT} semantics. In contrast to {@link #readPut(ObjectNode, Object,
+	 * ObjectMapper)}, linkable associations are replaced by the ones contained in the payload as nested elements are not
+	 * exposed as association resources and the payload is the only place to express them.
+	 *
+	 * @param source must not be {@literal null}.
+	 * @param target must not be {@literal null}.
+	 * @param mapper must not be {@literal null}.
+	 * @throws Exception
+	 */
+	private void mergeArrayElement(ObjectNode source, Object target, ObjectMapper mapper) throws Exception {
+
+		Object intermediate = mapper.readerFor(target.getClass()).readValue(source);
+		mergeForPut(intermediate, target, mapper, true);
+	}
+
+	/**
+	 * Merges the state of the given source object onto the target one applying {@literal PUT} semantics.
+	 *
+	 * @param source can be {@literal null}.
+	 * @param target can be {@literal null}.
+	 * @param mapper must not be {@literal null}.
+	 * @param replaceLinkableAssociations whether to replace linkable associations of the target with the ones of the
+	 *          source. If {@literal false}, linkable associations are left untouched.
+	 * @return
+	 */
+	@Nullable
+	private <T> T mergeForPut(T source, T target, final ObjectMapper mapper, boolean replaceLinkableAssociations) {
 
 		Assert.notNull(mapper, "ObjectMapper must not be null");
 
@@ -188,7 +221,13 @@ public class DomainObjectReader {
 					MergingPropertyHandler propertyHandler = new MergingPropertyHandler(source, target, it, mapper);
 
 					it.doWithProperties(propertyHandler);
-					it.doWithAssociations(new LinkedAssociationSkippingAssociationHandler(associationLinks, propertyHandler));
+
+					if (replaceLinkableAssociations) {
+						it.doWithAssociations((SimpleAssociationHandler) association -> propertyHandler
+								.doWithPersistentProperty(association.getInverse()));
+					} else {
+						it.doWithAssociations(new LinkedAssociationSkippingAssociationHandler(associationLinks, propertyHandler));
+					}
 
 					// Need to copy unmapped properties as the PersistentProperty model currently does not contain any transient
 					// properties
@@ -423,7 +462,7 @@ public class DomainObjectReader {
 			if (ObjectNode.class.isInstance(jsonNode)) {
 
 				nestedObjectFound = true;
-				readPut((ObjectNode) jsonNode, next, mapper);
+				mergeArrayElement((ObjectNode) jsonNode, next, mapper);
 			}
 		}
 
@@ -726,6 +765,13 @@ public class DomainObjectReader {
 			Optional<Object> sourceValue = Optional.ofNullable(sourceAccessor.getProperty(property));
 
 			if (property.isImmutable()) {
+				targetAccessor.setProperty(property, sourceValue.orElse(null));
+				return;
+			}
+
+			// A linkable association points to a different aggregate. Replace the reference rather than merging the
+			// source state into the referenced instance.
+			if (associationLinks.isLinkableAssociation(property)) {
 				targetAccessor.setProperty(property, sourceValue.orElse(null));
 				return;
 			}

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/json/DomainObjectReaderUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/json/DomainObjectReaderUnitTests.java
@@ -73,6 +73,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
  * @author Mathias Düsterhöft
  * @author Ken Dombeck
  * @author Thomas Mrozinski
+ * @author Takeshi Ogawa
  */
 @ExtendWith(MockitoExtension.class)
 class DomainObjectReaderUnitTests {
@@ -110,6 +111,8 @@ class DomainObjectReaderUnitTests {
 		mappingContext.getPersistentEntity(BugModel.class);
 		mappingContext.getPersistentEntity(ArrayListHolder.class);
 		mappingContext.getPersistentEntity(MapWrapper.class);
+		mappingContext.getPersistentEntity(Playlist.class);
+		mappingContext.getPersistentEntity(Track.class);
 		mappingContext.afterPropertiesSet();
 
 		this.entities = new PersistentEntities(Collections.singleton(mappingContext));
@@ -839,6 +842,39 @@ class DomainObjectReaderUnitTests {
 		assertThat(result.items.get(2).some).isEqualTo("yetAnotherValue");
 	}
 
+	@Test // GH-2596
+	void patchReplacesReferenceOfEntityNestedInArray() throws Exception {
+
+		Associations associations = mock(Associations.class);
+		when(associations.isLinkableAssociation(any(PersistentProperty.class)))
+				.thenAnswer(invocation -> invocation.<PersistentProperty<?>> getArgument(0).isAssociation());
+
+		DomainObjectReader reader = new DomainObjectReader(entities, associations);
+
+		Tag first = new Tag();
+		Tag second = new Tag();
+
+		Track track = new Track();
+		track.label = "old label";
+		track.tag = first;
+
+		Playlist playlist = new Playlist();
+		playlist.tracks.add(track);
+
+		SimpleModule module = new SimpleModule().addDeserializer(Tag.class,
+				new SelectValueByIdSerializer<Tag>(Map.of(first.id, first, second.id, second)));
+		ObjectMapper mapper = JsonMapper.builder().addModule(module).build();
+
+		ObjectNode node = (ObjectNode) mapper.readTree(
+				String.format("{ \"tracks\" : [ { \"label\" : \"new label\", \"tag\" : \"%s\" } ] }", second.id));
+
+		Playlist result = reader.doMerge(node, playlist, mapper);
+
+		assertThat(result.tracks).hasSize(1);
+		assertThat(result.tracks.get(0).label).isEqualTo("new label");
+		assertThat(result.tracks.get(0).tag).isSameAs(second);
+	}
+
 	@SuppressWarnings("unchecked")
 	private static <T> T as(Object source, Class<T> type) {
 
@@ -1116,6 +1152,20 @@ class DomainObjectReaderUnitTests {
 	static class Tag {
 		@Id UUID id = UUID.randomUUID();
 		String name;
+	}
+
+	// GH-2596
+
+	@JsonAutoDetect(fieldVisibility = Visibility.ANY)
+	static class Playlist {
+		@Id UUID id = UUID.randomUUID();
+		List<Track> tracks = new ArrayList<Track>();
+	}
+
+	@JsonAutoDetect(fieldVisibility = Visibility.ANY)
+	static class Track {
+		String label;
+		@Reference Tag tag;
 	}
 
 	static class SelectValueByIdSerializer<T> extends ValueDeserializer<T> {


### PR DESCRIPTION
Closes #2596.

Since #2358, an object nested in an array is applied to the existing element at the same index via `readPut(…)` to obtain PUT semantics (RFC 7386). `mergeForPut(…)` skips linkable associations, which is intended for top-level `PUT` requests where associations are managed through association resources. Nested elements have no association resource, so the request body is the only place to express them. As a result, non-association properties of an existing element were updated while its associations kept their previous values, whereas appended elements and elements written into an empty collection resolved them properly.

This change

- merges existing array elements through a dedicated path (`mergeArrayElement`) that forwards linkable associations to `MergingPropertyHandler`,
- makes `MergingPropertyHandler` replace a linkable association with the reference contained in the payload instead of merging the source state into the referenced instance,
- leaves the top-level `PUT` path (`readPut` / `mergeForPut`) unchanged,
- adds `patchReplacesReferenceOfEntityNestedInArray` to `DomainObjectReaderUnitTests` (fails on `main`, passes with this change; `handlesEntityNestedInAnArrayLikePutForPatchRequest` from #2358 keeps passing).

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/main/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/main/etc/ide) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
