### PR TITLE
Fixed search resource routing when repository name is longer than 'search' keyword

### DIFF
--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaWebTests.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaWebTests.java
@@ -74,6 +74,7 @@ import com.jayway.jsonpath.ReadContext;
  * @author Mark Paluch
  * @author Ľubomír Varga
  * @author Dario Seidl
+ * @author Steve Rutherford
  */
 @Transactional
 @ContextConfiguration(classes = JpaRepositoryConfig.class, initializers = JpaWebTests.JpaContextInitializer.class)

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaWebTests.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/JpaWebTests.java
@@ -754,6 +754,19 @@ public class JpaWebTests extends CommonWebTests {
 		assertThat(observationContext.getPathPattern()).isEqualTo("/authors/{id}");
 	}
 
+	@Test // DATAREST-1495
+	void searchResourceIsAccessibleWhenRepositoryNameIsLongerThanSearchKeyword() throws Exception {
+
+		// "authors" has 7 characters, "search" has 6. Previously, AntPatternComparator ranked
+		// /authors/{id} (length 10) higher than /{repository}/search (length 9), causing
+		// GET /authors/search to be routed to the item-resource handler and return 400 BAD_REQUEST
+		// (because "search" could not be bound as an entity ID) instead of being correctly routed
+		// to the search-resource handler. AuthorRepository has no query methods, so the search
+		// resource handler correctly returns 404 NOT_FOUND (no searches exposed) — not 400.
+		mockMvc.perform(get("/authors/search").accept(MediaType.APPLICATION_JSON)) //
+				.andExpect(status().isNotFound());
+	}
+
 	private List<Link> preparePersonResources(Person primary, Person... persons) throws Exception {
 
 		Link peopleLink = client.discoverUnique(LinkRelation.of("people"));

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryRestHandlerMapping.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryRestHandlerMapping.java
@@ -19,6 +19,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -182,6 +183,106 @@ public class RepositoryRestHandlerMapping extends BasePathAwareHandlerMapping {
 		jpaHelper.map(JpaHelper::getInterceptors) //
 				.orElseGet(() -> Collections.emptyList()) //
 				.forEach(interceptors::add);
+	}
+
+	/**
+	 * Returns a {@link Comparator} for {@link RequestMappingInfo} that first applies a SDR-specific tiebreaker before
+	 * delegating to the default Spring MVC comparator. The tiebreaker ensures that patterns with a literal last path
+	 * segment (e.g. {@code /{repository}/search}) are preferred over patterns whose last path segment is a variable
+	 * (e.g. {@code /{repository}/{id}} or {@code /authors/{id}}). This prevents the {@code AntPatternComparator}'s
+	 * length-based heuristic from incorrectly routing {@code GET /authors/search} to the item-resource handler when the
+	 * repository name happens to be longer than the keyword "search".
+	 *
+	 * @see <a href="https://github.com/spring-projects/spring-data-rest/issues/1853">DATAREST-1495</a>
+	 */
+	@Override
+	protected Comparator<RequestMappingInfo> getMappingComparator(HttpServletRequest request) {
+
+		Comparator<RequestMappingInfo> defaultComparator = super.getMappingComparator(request);
+
+		return (info1, info2) -> {
+
+			int result = compareByLastSegmentLiteralness(info1, info2, request);
+
+			if (result != 0) {
+				return result;
+			}
+
+			return defaultComparator.compare(info1, info2);
+		};
+	}
+
+	/**
+	 * Compares two {@link RequestMappingInfo} instances by whether their last matched path segment is a literal or a
+	 * variable. Patterns whose last segment is a literal (e.g. {@code /search}) are considered more specific and ranked
+	 * higher (return value {@code -1}) than patterns whose last segment is a path variable (e.g. {@code /{id}}).
+	 *
+	 * @param info1 must not be {@literal null}.
+	 * @param info2 must not be {@literal null}.
+	 * @param request must not be {@literal null}.
+	 * @return {@code -1} if info1's last segment is literal and info2's is a variable, {@code 1} for the inverse,
+	 *         {@code 0} if both are the same kind.
+	 */
+	private static int compareByLastSegmentLiteralness(RequestMappingInfo info1, RequestMappingInfo info2,
+			HttpServletRequest request) {
+
+		String pattern1 = getMatchedPattern(info1, request);
+		String pattern2 = getMatchedPattern(info2, request);
+
+		if (pattern1 == null || pattern2 == null) {
+			return 0;
+		}
+
+		boolean lastSegment1IsLiteral = isLastSegmentLiteral(pattern1);
+		boolean lastSegment2IsLiteral = isLastSegmentLiteral(pattern2);
+
+		if (lastSegment1IsLiteral && !lastSegment2IsLiteral) {
+			return -1;
+		}
+
+		if (!lastSegment1IsLiteral && lastSegment2IsLiteral) {
+			return 1;
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Returns the matched pattern string for the given {@link RequestMappingInfo} and request, or {@literal null} if
+	 * none can be determined.
+	 *
+	 * @param info must not be {@literal null}.
+	 * @param request must not be {@literal null}.
+	 * @return the matched pattern string, or {@literal null}.
+	 */
+	private static @Nullable String getMatchedPattern(RequestMappingInfo info, HttpServletRequest request) {
+
+		PathPatternsRequestCondition pathPatternsCondition = info.getPathPatternsCondition();
+
+		if (pathPatternsCondition != null) {
+			PathPatternsRequestCondition matchingCondition = pathPatternsCondition.getMatchingCondition(request);
+			if (matchingCondition != null) {
+				return matchingCondition.getFirstPattern().getPatternString();
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns whether the last path segment of the given pattern is a literal (i.e. not a path variable or wildcard).
+	 * For example, {@code /{repository}/search} returns {@code true}, while {@code /{repository}/{id}} returns
+	 * {@code false}.
+	 *
+	 * @param pattern must not be {@literal null}.
+	 * @return {@code true} if the last segment is a literal, {@code false} otherwise.
+	 */
+	static boolean isLastSegmentLiteral(String pattern) {
+
+		int lastSlash = pattern.lastIndexOf('/');
+		String lastSegment = lastSlash >= 0 ? pattern.substring(lastSlash + 1) : pattern;
+
+		return !lastSegment.startsWith("{") && !lastSegment.startsWith("*");
 	}
 
 	@Override

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryRestHandlerMapping.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/RepositoryRestHandlerMapping.java
@@ -62,6 +62,7 @@ import org.springframework.web.util.pattern.PathPatternParser;
  * @author Jon Brisbin
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Steve Rutherford
  */
 @SuppressWarnings("NullAway")
 public class RepositoryRestHandlerMapping extends BasePathAwareHandlerMapping {

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/RepositoryRestHandlerMappingUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/RepositoryRestHandlerMappingUnitTests.java
@@ -56,6 +56,7 @@ import org.springframework.web.util.pattern.PathPattern;
  * @author Oliver Gierke
  * @author Greg Turnquist
  * @author Mark Paluch
+ * @author Steve Rutherford
  */
 @ExtendWith(MockitoExtension.class)
 class RepositoryRestHandlerMappingUnitTests {

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/RepositoryRestHandlerMappingUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/RepositoryRestHandlerMappingUnitTests.java
@@ -294,6 +294,41 @@ class RepositoryRestHandlerMappingUnitTests {
 		assertThatCode(() -> handlerMapping.get().getHandlerInternal(request)).doesNotThrowAnyException();
 	}
 
+	@Test // DATAREST-1495
+	void prefersSearchResourceOverItemResourceWhenRepositoryNameIsLongerThanSearchKeyword() throws Exception {
+
+		// "authors" (7 chars) > "search" (6 chars), which previously caused AntPatternComparator to
+		// rank /authors/{id} higher than /{repository}/search for GET /authors/search.
+		when(mappings.exportsTopLevelResourceFor("/authors")).thenReturn(true);
+
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/authors/search");
+
+		HandlerMethod method = handlerMapping.get().getHandlerInternal(request);
+
+		// Must resolve to the search listing handler, not the item-resource handler
+		Method searchListingMethod = RepositorySearchController.class.getMethod("listSearches",
+				RootResourceInformation.class);
+
+		assertThat(method).isNotNull();
+		assertThat(method.getMethod()).isEqualTo(searchListingMethod);
+	}
+
+	@Test // DATAREST-1495
+	void isLastSegmentLiteralReturnsTrueForLiteralSegments() {
+
+		assertThat(RepositoryRestHandlerMapping.isLastSegmentLiteral("/{repository}/search")).isTrue();
+		assertThat(RepositoryRestHandlerMapping.isLastSegmentLiteral("/people")).isTrue();
+		assertThat(RepositoryRestHandlerMapping.isLastSegmentLiteral("/people/search")).isTrue();
+	}
+
+	@Test // DATAREST-1495
+	void isLastSegmentLiteralReturnsFalseForVariableSegments() {
+
+		assertThat(RepositoryRestHandlerMapping.isLastSegmentLiteral("/{repository}/{id}")).isFalse();
+		assertThat(RepositoryRestHandlerMapping.isLastSegmentLiteral("/authors/{id}")).isFalse();
+		assertThat(RepositoryRestHandlerMapping.isLastSegmentLiteral("/{repository}")).isFalse();
+	}
+
 	private static Class<?> createProxy(Object source) {
 
 		ProxyFactory factory = new ProxyFactory(source);


### PR DESCRIPTION
Fixes [#1853](https://github.com/spring-projects/spring-data-rest/issues/1853)

**Root Cause:** `GET /authors/search` returned `400 BAD_REQUEST` due to Spring MVC's `AntPatternComparator` using string length as a tiebreaker. For a repository named "authors" (7 chars), the item-resource pattern `/authors/{id}` scored length 10 while the search pattern `/{repository}/search` scored length 9, causing the wrong handler to win. "search" was then incorrectly treated as an entity ID, producing a 400 error.

**Fix:** Overrode `getMappingComparator()` in `RepositoryRestHandlerMapping` to wrap the default Spring MVC comparator with a SDR-specific tiebreaker. The tiebreaker (`compareByLastSegmentLiteralness`) checks whether the last path segment of each matched pattern is a **literal** (e.g., `/search`) or a **variable** (e.g., `/{id}`). Patterns with a literal last segment are always ranked higher, ensuring `/{repository}/search` always beats `/{repository}/{id}` or `/authors/{id}` regardless of string length.

**Files changed (3):**
- `RepositoryRestHandlerMapping.java` — Added `getMappingComparator()` override with `compareByLastSegmentLiteralness()` and `isLastSegmentLiteral()` helpers; added `@author Steve Rutherford`
- `RepositoryRestHandlerMappingUnitTests.java` — Added 3 unit tests (handler resolution, `isLastSegmentLiteral` true/false cases); added `@author Steve Rutherford`
- `JpaWebTests.java` — Added integration test verifying `GET /authors/search` routes to the search handler (returns 404 "no searches exposed" instead of 400 "bad request"); added `@author Steve Rutherford`

---

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
