### PR TITLE
Added new `Associations.isUriResolvableAssociation()` method that separates URI resolvability from HTTP endpoint exposure.

### DIFF
--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/Member.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/Member.java
@@ -29,6 +29,7 @@ import jakarta.persistence.ManyToOne;
  * still be deserialized correctly via the {@code UriStringDeserializer}.
  *
  * @author Spring Data REST team
+ * @author Steve Rutherford
  * @see Profile
  * @see MemberRepository
  */

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/Member.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/Member.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.webmvc.jpa;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+
+/**
+ * A member entity that holds a {@link ManyToOne} association to a {@link Profile}. Used to reproduce the bug
+ * described in <a href="https://github.com/spring-projects/spring-data-rest/issues/1515">GH-1515</a>: when the
+ * {@code ANNOTATED} repository detection strategy is active and {@link ProfileRepository} is not annotated with
+ * {@code @RepositoryRestResource}, submitting a URI string for the {@code profile} field in a JSON payload must
+ * still be deserialized correctly via the {@code UriStringDeserializer}.
+ *
+ * @author Spring Data REST team
+ * @see Profile
+ * @see MemberRepository
+ */
+@Entity
+public class Member {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	private String username;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Profile profile;
+
+	protected Member() {}
+
+	public Member(String username) {
+		this.username = username;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public String getUsername() {
+		return username;
+	}
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	public Profile getProfile() {
+		return profile;
+	}
+
+	public void setProfile(Profile profile) {
+		this.profile = profile;
+	}
+}

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/MemberRepository.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/MemberRepository.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.webmvc.jpa;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+/**
+ * Repository for {@link Member} entities. Annotated with {@code @RepositoryRestResource} so that it is exported as
+ * an HTTP endpoint even when the {@code ANNOTATED} repository detection strategy is active. This contrasts with
+ * {@link ProfileRepository}, which is intentionally <em>not</em> annotated and therefore not HTTP-exported.
+ *
+ * @author Spring Data REST team
+ * @see Member
+ * @see ProfileRepository
+ */
+@RepositoryRestResource
+public interface MemberRepository extends CrudRepository<Member, Long> {
+}

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/MemberRepository.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/MemberRepository.java
@@ -24,6 +24,7 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
  * {@link ProfileRepository}, which is intentionally <em>not</em> annotated and therefore not HTTP-exported.
  *
  * @author Spring Data REST team
+ * @author Steve Rutherford
  * @see Member
  * @see ProfileRepository
  */

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/Profile.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/Profile.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.webmvc.jpa;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+/**
+ * A user profile entity used to test URI-to-entity deserialization when the ANNOTATED repository detection strategy is
+ * active. The corresponding {@link ProfileRepository} is intentionally <em>not</em> annotated with
+ * {@code @RepositoryRestResource}, so it is not exported as an HTTP endpoint under the ANNOTATED strategy. This
+ * reproduces the scenario described in
+ * <a href="https://github.com/spring-projects/spring-data-rest/issues/1515">GH-1515</a>.
+ *
+ * @author Spring Data REST team
+ * @see ProfileRepository
+ * @see Member
+ */
+@Entity
+public class Profile {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	private String name;
+
+	protected Profile() {}
+
+	public Profile(String name) {
+		this.name = name;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/Profile.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/Profile.java
@@ -27,6 +27,7 @@ import jakarta.persistence.Id;
  * <a href="https://github.com/spring-projects/spring-data-rest/issues/1515">GH-1515</a>.
  *
  * @author Spring Data REST team
+ * @author Steve Rutherford
  * @see ProfileRepository
  * @see Member
  */

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/ProfileRepository.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/ProfileRepository.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.webmvc.jpa;
+
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * Repository for {@link Profile} entities. Intentionally <em>not</em> annotated with
+ * {@code @RepositoryRestResource} so that it is <em>not</em> exported as an HTTP endpoint when the
+ * {@code ANNOTATED} repository detection strategy is active. This is the key precondition for reproducing the bug
+ * described in <a href="https://github.com/spring-projects/spring-data-rest/issues/1515">GH-1515</a>: even though
+ * this repository is not HTTP-exported, URI-based association resolution for {@link Member#getProfile()} must still
+ * work.
+ *
+ * @author Spring Data REST team
+ * @see Profile
+ * @see Member
+ */
+public interface ProfileRepository extends CrudRepository<Profile, Long> {
+}

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/ProfileRepository.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/main/java/org/springframework/data/rest/webmvc/jpa/ProfileRepository.java
@@ -26,6 +26,7 @@ import org.springframework.data.repository.CrudRepository;
  * work.
  *
  * @author Spring Data REST team
+ * @author Steve Rutherford
  * @see Profile
  * @see Member
  */

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/AnnotatedStrategyUriDeserializationIntegrationTests.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/AnnotatedStrategyUriDeserializationIntegrationTests.java
@@ -65,6 +65,7 @@ import org.springframework.web.context.WebApplicationContext;
  * regardless of whether that repository is exported as an HTTP endpoint.
  *
  * @author Spring Data REST team
+ * @author Steve Rutherford
  * @see <a href="https://github.com/spring-projects/spring-data-rest/issues/1515">GH-1515</a>
  */
 @ExtendWith(SpringExtension.class)

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/AnnotatedStrategyUriDeserializationIntegrationTests.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/AnnotatedStrategyUriDeserializationIntegrationTests.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2018-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.webmvc.jpa;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.rest.core.mapping.RepositoryDetectionStrategy.RepositoryDetectionStrategies;
+import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
+import org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguration;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Integration tests for GH-1515 (DATAREST-1195): verifies that URI-to-entity deserialization for association
+ * properties works correctly when the {@code ANNOTATED} repository detection strategy is active and the target
+ * repository is <em>not</em> annotated with {@code @RepositoryRestResource}.
+ *
+ * <h3>Scenario</h3>
+ * <ul>
+ *   <li>{@link ProfileRepository} is <em>not</em> annotated → not exported as an HTTP endpoint under ANNOTATED
+ *       strategy.</li>
+ *   <li>{@link MemberRepository} <em>is</em> annotated → exported as an HTTP endpoint.</li>
+ *   <li>A POST to {@code /members} with a JSON body that references a {@link Profile} by URI (e.g.
+ *       {@code "profile": "/profiles/1"}) must succeed without a {@code JsonMappingException}.</li>
+ * </ul>
+ *
+ * <h3>Root cause (before fix)</h3>
+ * {@code Associations.isLinkableAssociation()} checked {@code metadata.isExported()} for the target type. Under the
+ * ANNOTATED strategy, un-annotated repositories return {@code isExported() == false}, so the check returned
+ * {@code false} and the {@code UriStringDeserializer} was never registered for the {@code profile} property. Jackson
+ * then fell back to its default deserializer, which cannot construct a {@link Profile} from a plain URI string.
+ *
+ * <h3>Fix</h3>
+ * A new {@code Associations.isUriResolvableAssociation()} method is used in the deserializer modifier. It returns
+ * {@code true} whenever a repository (and therefore a {@code ResourceMetadata}) exists for the target type,
+ * regardless of whether that repository is exported as an HTTP endpoint.
+ *
+ * @author Spring Data REST team
+ * @see <a href="https://github.com/spring-projects/spring-data-rest/issues/1515">GH-1515</a>
+ */
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@Transactional
+@ContextConfiguration(
+		classes = { JpaRepositoryConfig.class, RepositoryRestMvcConfiguration.class,
+				AnnotatedStrategyUriDeserializationIntegrationTests.AnnotatedStrategyConfig.class })
+class AnnotatedStrategyUriDeserializationIntegrationTests {
+
+	@Autowired WebApplicationContext context;
+	@Autowired ProfileRepository profileRepository;
+	@Autowired MemberRepository memberRepository;
+
+	MockMvc mockMvc;
+
+	/**
+	 * Configures the {@code ANNOTATED} repository detection strategy. This is the critical precondition: with this
+	 * strategy, {@link ProfileRepository} (which has no {@code @RepositoryRestResource} annotation) is NOT exported as
+	 * an HTTP endpoint, while {@link MemberRepository} (which IS annotated) is exported.
+	 */
+	@Configuration
+	static class AnnotatedStrategyConfig {
+
+		@Bean
+		RepositoryRestConfigurer annotatedStrategyConfigurer() {
+			return RepositoryRestConfigurer.withConfig(
+					config -> config.setRepositoryDetectionStrategy(RepositoryDetectionStrategies.ANNOTATED));
+		}
+	}
+
+	@BeforeEach
+	void setUp() {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON))
+				.build();
+	}
+
+	/**
+	 * Regression test for GH-1515.
+	 * <p>
+	 * POSTs a {@link Member} payload that references a {@link Profile} by URI. Before the fix, this threw a
+	 * {@code JsonMappingException} because the {@code UriStringDeserializer} was not registered for the {@code profile}
+	 * property when the ANNOTATED strategy was active and {@link ProfileRepository} was not annotated.
+	 */
+	@Test // GH-1515
+	void postMemberWithProfileUriSucceedsUnderAnnotatedDetectionStrategy() throws Exception {
+
+		// Persist a Profile to reference by URI
+		Profile profile = profileRepository.save(new Profile("Test Profile"));
+		Long profileId = profile.getId();
+
+		// Build a JSON payload that references the profile by URI — exactly as described in the issue
+		String payload = String.format("""
+				{
+				  "username": "testuser",
+				  "profile": "/profiles/%d"
+				}
+				""", profileId);
+
+		// POST to /members — must succeed (2xx) without a JsonMappingException.
+		// Before the fix this returned 400 Bad Request with:
+		//   "JSON parse error: Can not construct instance of Profile:
+		//    no String-argument constructor/factory method to deserialize from String value ('/profiles/1')"
+		mockMvc.perform(post("/members")
+				.content(payload)
+				.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isCreated());
+	}
+
+	/**
+	 * Verifies that the ANNOTATED strategy correctly suppresses the HTTP endpoint for {@link ProfileRepository}: a GET
+	 * to {@code /profiles} must return 404 (the collection resource is not exposed).
+	 * <p>
+	 * This confirms that the fix does not accidentally re-expose the un-annotated repository as an HTTP endpoint.
+	 */
+	@Test // GH-1515
+	void profileRepositoryIsNotExposedAsHttpEndpointUnderAnnotatedStrategy() throws Exception {
+
+		mockMvc.perform(get("/profiles"))
+				.andExpect(status().isNotFound());
+	}
+
+	/**
+	 * Verifies that the ANNOTATED strategy correctly exposes the HTTP endpoint for {@link MemberRepository}: a GET to
+	 * {@code /members} must return 200 OK.
+	 */
+	@Test // GH-1515
+	void memberRepositoryIsExposedAsHttpEndpointUnderAnnotatedStrategy() throws Exception {
+
+		mockMvc.perform(get("/members"))
+				.andExpect(status().isOk());
+	}
+}

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/PersistentEntityJackson2Module.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/PersistentEntityJackson2Module.java
@@ -469,7 +469,8 @@ public class PersistentEntityJackson2Module extends SimpleModule {
 						continue;
 					}
 
-					if (!associationLinks.isUriResolvableAssociation(persistentProperty)) {
+					if (!associationLinks.isUriResolvableAssociation(persistentProperty)
+							&& !associationLinks.isLinkableAssociation(persistentProperty)) {
 						continue;
 					}
 

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/PersistentEntityJackson2Module.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/PersistentEntityJackson2Module.java
@@ -469,7 +469,7 @@ public class PersistentEntityJackson2Module extends SimpleModule {
 						continue;
 					}
 
-					if (!associationLinks.isLinkableAssociation(persistentProperty)) {
+					if (!associationLinks.isUriResolvableAssociation(persistentProperty)) {
 						continue;
 					}
 

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/PersistentEntityJackson2Module.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/PersistentEntityJackson2Module.java
@@ -101,6 +101,7 @@ import com.fasterxml.jackson.databind.util.NameTransformer;
  * @author Oliver Gierke
  * @author Greg Turnquist
  * @author Alex Leigh
+ * @author Steve Rutherford
  * @deprecated since 5.0, in favor of {@link PersistentEntityJacksonModule}.
  */
 @Deprecated(since = "5.0", forRemoval = true)

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/PersistentEntityJacksonModule.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/PersistentEntityJacksonModule.java
@@ -467,7 +467,8 @@ public class PersistentEntityJacksonModule extends SimpleModule {
 						continue;
 					}
 
-					if (!associationLinks.isUriResolvableAssociation(persistentProperty)) {
+					if (!associationLinks.isUriResolvableAssociation(persistentProperty)
+							&& !associationLinks.isLinkableAssociation(persistentProperty)) {
 						continue;
 					}
 

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/PersistentEntityJacksonModule.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/PersistentEntityJacksonModule.java
@@ -467,7 +467,7 @@ public class PersistentEntityJacksonModule extends SimpleModule {
 						continue;
 					}
 
-					if (!associationLinks.isLinkableAssociation(persistentProperty)) {
+					if (!associationLinks.isUriResolvableAssociation(persistentProperty)) {
 						continue;
 					}
 

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/PersistentEntityJacksonModule.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/PersistentEntityJacksonModule.java
@@ -101,6 +101,7 @@ import com.fasterxml.jackson.databind.JsonSerializer;
  * @author Oliver Gierke
  * @author Greg Turnquist
  * @author Alex Leigh
+ * @author Steve Rutherford
  * @since 5.0
  */
 public class PersistentEntityJacksonModule extends SimpleModule {

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/mapping/Associations.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/mapping/Associations.java
@@ -135,7 +135,8 @@ public class Associations {
 	}
 
 	/**
-	 * Returns whether the given property is an association that is linkable.
+	 * Returns whether the given property is an association that is linkable, i.e. the target type is exported as an HTTP
+	 * resource. This is used to determine whether to render the association as a link during serialization.
 	 *
 	 * @param property must not be {@literal null}.
 	 * @return
@@ -156,6 +157,50 @@ public class Associations {
 
 		metadata = mappings.getMetadataFor(property.getActualType());
 		return metadata == null ? false : metadata.isExported();
+	}
+
+	/**
+	 * Returns whether the given property is an association whose target type can be resolved from a URI during
+	 * deserialization. Unlike {@link #isLinkableAssociation(PersistentProperty)}, this does <em>not</em> require the
+	 * target type's repository to be exported as an HTTP endpoint — it only requires that a repository (and therefore a
+	 * {@link org.springframework.data.rest.core.mapping.ResourceMetadata}) exists for the target type. This separation
+	 * ensures that the {@code ANNOTATED} repository detection strategy (which suppresses HTTP endpoint exposure for
+	 * un-annotated repositories) does not inadvertently break URI-to-entity deserialization for association properties.
+	 *
+	 * <p>The owner-level check is intentionally relaxed compared to {@link #isLinkableAssociation(PersistentProperty)}:
+	 * rather than delegating to {@link ResourceMetadata#isExported(PersistentProperty)} (which internally checks
+	 * whether the target type is exported), this method only checks whether the property has been explicitly suppressed
+	 * via {@code @RestResource(exported = false)} on the property itself. This avoids the circular dependency where
+	 * the target type's export status would prevent URI deserialization from working.
+	 *
+	 * @param property must not be {@literal null}.
+	 * @return {@literal true} if the property is an association, is not explicitly suppressed, and a repository exists
+	 *         for its target type.
+	 * @since 4.4
+	 * @see <a href="https://github.com/spring-projects/spring-data-rest/issues/1515">DATAREST-1195</a>
+	 */
+	public boolean isUriResolvableAssociation(PersistentProperty<?> property) {
+
+		Assert.notNull(property, "PersistentProperty must not be null");
+
+		if (!property.isAssociation() || config.isLookupType(property.getActualType())) {
+			return false;
+		}
+
+		// Check if the property has been explicitly suppressed via @RestResource(exported = false).
+		// We do NOT delegate to ownerMetadata.isExported(property) here because that method internally
+		// checks whether the target type's repository is exported — which is exactly the check we want
+		// to bypass for URI deserialization purposes (GH-1515).
+		org.springframework.data.rest.core.annotation.RestResource annotation =
+				property.findAnnotation(org.springframework.data.rest.core.annotation.RestResource.class);
+		if (annotation != null && !annotation.exported()) {
+			return false;
+		}
+
+		// A repository must exist for the target type, but it does not need to be exported as an HTTP endpoint.
+		// This allows URI-based association resolution to work even when the ANNOTATED detection strategy is used
+		// and the target repository is not annotated with @RepositoryRestResource.
+		return mappings.getMetadataFor(property.getActualType()) != null;
 	}
 
 	private TemplateVariables getProjectionVariable(PersistentProperty<?> property) {

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/mapping/Associations.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/mapping/Associations.java
@@ -43,6 +43,7 @@ import org.springframework.util.Assert;
  * @author Oliver Gierke
  * @author Greg Turnquist
  * @author Haroun Pacquee
+ * @author Steve Rutherford
  * @since 2.1
  */
 public class Associations {

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/mapping/AssociationsUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/mapping/AssociationsUnitTests.java
@@ -42,6 +42,7 @@ import org.springframework.data.rest.core.config.ProjectionDefinitionConfigurati
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.core.mapping.PersistentEntitiesResourceMappings;
 import org.springframework.data.rest.core.mapping.ResourceMappings;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.hateoas.Link;
 
 /**
@@ -154,6 +155,109 @@ class AssociationsUnitTests {
 		assertThat(links).contains(Link.of("/relatedAndExported{?" + projectionParameterName + "}", "relatedAndExported"));
 	}
 
+	// ---------------------------------------------------------------------------
+	// Tests for isUriResolvableAssociation (DATAREST-1195 / issue #1515)
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Verifies that {@code isUriResolvableAssociation} returns {@code true} for an association whose target type has a
+	 * repository that is exported (the common case — same result as {@code isLinkableAssociation}).
+	 */
+	@Test // GH-1515
+	void isUriResolvableAssociationReturnsTrueWhenTargetRepositoryIsExported() {
+
+		KeyValuePersistentEntity<?, ? extends KeyValuePersistentProperty<?>> rootEntity = mappingContext
+				.getRequiredPersistentEntity(Root.class);
+		KeyValuePersistentProperty<?> prop = rootEntity.getRequiredPersistentProperty("relatedAndExported");
+
+		assertThat(associations.isUriResolvableAssociation(prop)).isTrue();
+	}
+
+	/**
+	 * Verifies that {@code isUriResolvableAssociation} returns {@code false} when no repository (and therefore no
+	 * {@link org.springframework.data.rest.core.mapping.ResourceMetadata}) exists for the target type. This mirrors the
+	 * behaviour of {@code isLinkableAssociation} in the same scenario.
+	 * <p>
+	 * Note: we use a mock {@link ResourceMappings} that returns {@code null} for {@link RelatedButNotExported} to
+	 * simulate the real {@link org.springframework.data.rest.core.mapping.RepositoryResourceMappings} behaviour, which
+	 * only adds entities to its cache when a repository exists for them.
+	 */
+	@Test // GH-1515
+	void isUriResolvableAssociationReturnsFalseWhenNoRepositoryExistsForTargetType() {
+
+		KeyValuePersistentEntity<?, ? extends KeyValuePersistentProperty<?>> rootEntity = mappingContext
+				.getRequiredPersistentEntity(Root.class);
+		KeyValuePersistentProperty<?> prop = rootEntity.getRequiredPersistentProperty("relatedButNotExported");
+
+		// Use a mock ResourceMappings that returns null for RelatedButNotExported,
+		// simulating RepositoryResourceMappings when no repository exists for the target type.
+		ResourceMappings noRepoMappings = mock(ResourceMappings.class);
+		doReturn(null).when(noRepoMappings).getMetadataFor(RelatedButNotExported.class);
+		Associations noRepoAssociations = new Associations(noRepoMappings, configuration);
+
+		assertThat(noRepoAssociations.isUriResolvableAssociation(prop)).isFalse();
+	}
+
+	/**
+	 * Core regression test for DATAREST-1195 / GH-1515.
+	 * <p>
+	 * When the {@code ANNOTATED} repository detection strategy is used, a repository that is <em>not</em> annotated with
+	 * {@code @RepositoryRestResource} is not exported as an HTTP endpoint ({@code isExported() == false}). Before the
+	 * fix, {@code isLinkableAssociation} returned {@code false} in this case, which prevented the
+	 * {@code UriStringDeserializer} from being registered and caused a {@code JsonMappingException} when a URI string
+	 * was submitted for the association property.
+	 * <p>
+	 * After the fix, {@code isUriResolvableAssociation} returns {@code true} as long as a repository exists for the
+	 * target type — regardless of whether that repository is exported as an HTTP endpoint.
+	 */
+	@Test // GH-1515
+	void isUriResolvableAssociationReturnsTrueEvenWhenTargetRepositoryIsNotExportedViaAnnotatedStrategy() {
+
+		// Build a mapping context that knows about both AnnotatedStrategyOwner and its
+		// association target UnexportedTarget (which has a repository but is NOT annotated).
+		KeyValueMappingContext<?, ?> ctx = new KeyValueMappingContext<>();
+		ctx.getPersistentEntity(AnnotatedStrategyOwner.class);
+		ctx.getPersistentEntity(UnexportedTarget.class);
+
+		// Use a mock ResourceMappings that:
+		//   - returns a non-null but NOT-exported ResourceMetadata for UnexportedTarget,
+		//     simulating the ANNOTATED strategy for an un-annotated repository.
+		// Note: the owner-level check in isUriResolvableAssociation only looks at the
+		// @RestResource(exported = false) annotation on the property itself, NOT at
+		// ownerMetadata.isExported(property) (which would transitively check the target type's
+		// export status and defeat the purpose of the fix).
+		org.springframework.data.rest.core.mapping.ResourceMetadata unexportedMetadata =
+				mock(org.springframework.data.rest.core.mapping.ResourceMetadata.class);
+		doReturn(false).when(unexportedMetadata).isExported();
+
+		ResourceMappings annotatedMappings = mock(ResourceMappings.class);
+		doReturn(unexportedMetadata).when(annotatedMappings).getMetadataFor(UnexportedTarget.class);
+
+		Associations annotatedAssociations = new Associations(annotatedMappings, configuration);
+
+		KeyValuePersistentEntity<?, ? extends KeyValuePersistentProperty<?>> ownerEntity = ctx
+				.getRequiredPersistentEntity(AnnotatedStrategyOwner.class);
+		KeyValuePersistentProperty<?> prop = ownerEntity.getRequiredPersistentProperty("target");
+
+		// isLinkableAssociation must still return false (no HTTP link should be rendered)
+		assertThat(annotatedAssociations.isLinkableAssociation(prop)).isFalse();
+
+		// isUriResolvableAssociation must return true (URI deserialization must still work)
+		assertThat(annotatedAssociations.isUriResolvableAssociation(prop)).isTrue();
+	}
+
+	/**
+	 * Verifies that {@code isUriResolvableAssociation} rejects a {@code null} argument.
+	 */
+	@Test // GH-1515
+	void isUriResolvableAssociationRejectsNullProperty() {
+		assertThatIllegalArgumentException().isThrownBy(() -> associations.isUriResolvableAssociation(null));
+	}
+
+	// ---------------------------------------------------------------------------
+	// Helpers
+	// ---------------------------------------------------------------------------
+
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	private Association<? extends PersistentProperty<?>> getAssociation(Class<?> type, String name) {
 
@@ -164,6 +268,10 @@ class AssociationsUnitTests {
 		return new Association(property, null);
 	}
 
+	// ---------------------------------------------------------------------------
+	// Domain model for existing tests
+	// ---------------------------------------------------------------------------
+
 	static class Root {
 		@Reference RelatedAndExported relatedAndExported;
 		@Reference RelatedButNotExported relatedButNotExported;
@@ -173,4 +281,77 @@ class AssociationsUnitTests {
 	static class RelatedAndExported {}
 
 	static class RelatedButNotExported {}
+
+	// ---------------------------------------------------------------------------
+	// Domain model for ANNOTATED-strategy regression tests (GH-1515)
+	// ---------------------------------------------------------------------------
+
+	/** Owner entity whose {@code target} association points to an un-annotated (not HTTP-exported) type. */
+	static class AnnotatedStrategyOwner {
+		@Reference UnexportedTarget target;
+	}
+
+	/**
+	 * Target entity that has a repository ({@link UnexportedTargetRepository}) but is NOT annotated with
+	 * {@code @RepositoryRestResource}, so under the {@code ANNOTATED} strategy it is not exported as an HTTP endpoint.
+	 */
+	static class UnexportedTarget {}
+
+	/** A repository for {@link UnexportedTarget} — intentionally NOT annotated with {@code @RepositoryRestResource}. */
+	interface UnexportedTargetRepository extends CrudRepository<UnexportedTarget, Long> {}
+
+	/**
+	 * A {@link ResourceMappings} implementation that reports {@link UnexportedTarget} as having metadata (i.e. a
+	 * repository exists) but with {@code isExported() == false}, reproducing the effect of the {@code ANNOTATED}
+	 * detection strategy on an un-annotated repository.
+	 */
+	static class NotExportedTargetResourceMappings extends PersistentEntitiesResourceMappings {
+
+		NotExportedTargetResourceMappings(PersistentEntities entities) {
+			super(entities);
+		}
+
+		@Override
+		public org.springframework.data.rest.core.mapping.ResourceMetadata getMetadataFor(Class<?> type) {
+
+			org.springframework.data.rest.core.mapping.ResourceMetadata base = super.getMetadataFor(type);
+
+			if (base == null || !UnexportedTarget.class.equals(type)) {
+				return base;
+			}
+
+			// Wrap the metadata to report isExported() == false, simulating the ANNOTATED strategy
+			// for a repository that carries no @RepositoryRestResource annotation.
+			return new org.springframework.data.rest.core.mapping.ResourceMetadata() {
+
+				@Override public boolean isExported() { return false; }
+
+				@Override public Class<?> getDomainType() { return base.getDomainType(); }
+
+				@Override public org.springframework.hateoas.LinkRelation getRel() { return base.getRel(); }
+
+				@Override public org.springframework.hateoas.LinkRelation getItemResourceRel() { return base.getItemResourceRel(); }
+
+				@Override public org.springframework.data.rest.core.Path getPath() { return base.getPath(); }
+
+				@Override public boolean isPagingResource() { return base.isPagingResource(); }
+
+				@Override public org.springframework.data.rest.core.mapping.ResourceDescription getDescription() { return base.getDescription(); }
+
+				@Override public org.springframework.data.rest.core.mapping.ResourceDescription getItemResourceDescription() { return base.getItemResourceDescription(); }
+
+				@Override public java.util.Optional<Class<?>> getExcerptProjection() { return base.getExcerptProjection(); }
+
+				@Override public org.springframework.data.rest.core.mapping.SearchResourceMappings getSearchResourceMappings() { return base.getSearchResourceMappings(); }
+
+				@Override public org.springframework.data.rest.core.mapping.SupportedHttpMethods getSupportedHttpMethods() { return base.getSupportedHttpMethods(); }
+
+				@Override public org.springframework.data.rest.core.mapping.ResourceMapping getMappingFor(org.springframework.data.mapping.PersistentProperty<?> property) { return base.getMappingFor(property); }
+
+				@Override public boolean isExported(org.springframework.data.mapping.PersistentProperty<?> property) { return base.isExported(property); }
+
+				@Override public org.springframework.data.rest.core.mapping.PropertyAwareResourceMapping getProperty(String mappedPath) { return base.getProperty(mappedPath); }
+			};
+		}
+	}
 }

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/mapping/AssociationsUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/mapping/AssociationsUnitTests.java
@@ -47,6 +47,7 @@ import org.springframework.hateoas.Link;
 
 /**
  * @author Oliver Gierke
+ * @author Steve Rutherford
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)


### PR DESCRIPTION
Fixes [#1515](https://github.com/spring-projects/spring-data-rest/issues/1515)

**Root Cause:** When the `ANNOTATED` repository detection strategy is active, repositories without `@RepositoryRestResource` have `isExported() == false`. The `AssociationUriResolvingDeserializerModifier` in both `PersistentEntityJacksonModule` and `PersistentEntityJackson2Module` used `Associations.isLinkableAssociation()` to decide whether to register a `UriStringDeserializer` for association properties. That method checks `metadata.isExported()` for the target type — which returns `false` under ANNOTATED for un-annotated repositories. The deeper issue was that `PersistentPropertyResourceMapping.isExported()` also checks the target type's export status, creating a chain where `ownerMetadata.isExported(property)` returned `false` even for the owner's property check. As a result, `UriStringDeserializer` was never registered and Jackson threw a `JsonMappingException` (400 Bad Request) when a URI string was submitted for the association.

**Fix:** A new `Associations.isUriResolvableAssociation()` method separates URI resolvability from HTTP endpoint exposure. It returns `true` whenever a `ResourceMetadata` (i.e. a repository) exists for the target type, regardless of export status. The owner-level check only looks for an explicit `@RestResource(exported = false)` annotation on the property itself — bypassing the circular dependency where the target type's export status would prevent URI deserialization. Both Jackson modules now use `isUriResolvableAssociation()` for deserialization while `isLinkableAssociation()` continues to be used for serialization (link rendering), where the HTTP export check is correct and intentional.

**Test coverage added (9 files, 586 lines):**
- `AssociationsUnitTests`: 4 new unit tests for `isUriResolvableAssociation` (all 14 tests pass)
- `AnnotatedStrategyUriDeserializationIntegrationTests`: Full JPA integration test with `Member`/`@ManyToOne Profile` scenario — all 3 tests pass: POST succeeds (201), `/profiles` returns 404 (not exposed), `/members` returns 200 (exposed)
---


- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
