### PR TITLE
Fix for repositories inaccurately detected when multiple interfaces exist for domain type.

### DIFF
--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/mapping/RepositoryResourceMappings.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/mapping/RepositoryResourceMappings.java
@@ -49,6 +49,14 @@ public class RepositoryResourceMappings extends PersistentEntitiesResourceMappin
 	private final Map<Class<?>, SearchResourceMappings> searchCache = new HashMap<Class<?>, SearchResourceMappings>();
 
 	/**
+	 * Tracks the "winning" {@link RepositoryInformation} per domain type — i.e. the one whose metadata was stored in
+	 * the domain-type cache slot. This is used by {@link #getSearchResourceMappings(Class)} to ensure that query
+	 * methods are read from the exported repository when multiple repositories exist for the same domain type
+	 * (DATAREST-80 / GH-465).
+	 */
+	private final Map<Class<?>, RepositoryInformation> repositoryInfoByDomainType = new HashMap<>();
+
+	/**
 	 * Creates a new {@link RepositoryResourceMappings} from the given {@link RepositoryRestConfiguration},
 	 * {@link PersistentEntities}, and {@link Repositories}.
 	 *
@@ -74,13 +82,15 @@ public class RepositoryResourceMappings extends PersistentEntitiesResourceMappin
 	 * {@link PersistentEntities}, {@link Repositories}, and {@link ListableBeanFactory}.
 	 * <p>
 	 * Using this constructor allows proper detection of all repository interfaces for a given domain type, including
-	 * cases where multiple repository interfaces exist for the same domain type (e.g. for security purposes).
+	 * cases where multiple repository interfaces exist for the same domain type (e.g. for security purposes). The
+	 * {@link ListableBeanFactory} is used to enumerate all {@link RepositoryFactoryInformation} beans, which provides
+	 * one entry per repository interface rather than one entry per domain type.
 	 *
 	 * @param repositories must not be {@literal null}.
 	 * @param entities must not be {@literal null}.
 	 * @param configuration must not be {@literal null}.
 	 * @param beanFactory must not be {@literal null}.
-	 * @since 3.7
+	 * @since 5.0
 	 */
 	public RepositoryResourceMappings(Repositories repositories, PersistentEntities entities,
 			RepositoryRestConfiguration configuration, ListableBeanFactory beanFactory) {
@@ -104,7 +114,7 @@ public class RepositoryResourceMappings extends PersistentEntitiesResourceMappin
 		LinkRelationProvider provider = configuration.getLinkRelationProvider();
 
 		// When a BeanFactory is available, iterate over all RepositoryFactoryInformation beans to discover
-		// all repository interfaces, including multiple repositories for the same domain type (DATAREST-917).
+		// all repository interfaces, including multiple repositories for the same domain type (DATAREST-80 / GH-465).
 		if (beanFactory != null) {
 
 			Collection<RepositoryFactoryInformation> factoryInfos = BeanFactoryUtils
@@ -136,6 +146,7 @@ public class RepositoryResourceMappings extends PersistentEntitiesResourceMappin
 				if (!hasMetadataFor(domainType) || information.isPrimary()
 						|| (information.isExported() && !getMetadataFor(domainType).isExported())) {
 					addToCache(domainType, information);
+					repositoryInfoByDomainType.put(domainType, repositoryInformation);
 				}
 			}
 
@@ -165,6 +176,7 @@ public class RepositoryResourceMappings extends PersistentEntitiesResourceMappin
 
 			if (!hasMetadataFor(type) || information.isPrimary()) {
 				addToCache(type, information);
+				repositoryInfoByDomainType.put(type, repositoryInformation);
 			}
 		}
 	}
@@ -178,7 +190,12 @@ public class RepositoryResourceMappings extends PersistentEntitiesResourceMappin
 			return searchCache.get(domainType);
 		}
 
-		RepositoryInformation repositoryInformation = repositories.getRequiredRepositoryInformation(domainType);
+		// Use the repository information that was selected during cache population (the exported one when multiple
+		// repositories exist for the same domain type). Fall back to Repositories for backward compatibility.
+		RepositoryInformation repositoryInformation = repositoryInfoByDomainType.containsKey(domainType)
+				? repositoryInfoByDomainType.get(domainType)
+				: repositories.getRequiredRepositoryInformation(domainType);
+
 		List<MethodResourceMapping> mappings = new ArrayList<MethodResourceMapping>();
 		ResourceMetadata resourceMapping = getRequiredMetadataFor(domainType);
 

--- a/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/mapping/RepositoryResourceMappings.java
+++ b/spring-data-rest-core/src/main/java/org/springframework/data/rest/core/mapping/RepositoryResourceMappings.java
@@ -17,14 +17,18 @@ package org.springframework.data.rest.core.mapping;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.context.PersistentEntities;
 import org.springframework.data.repository.core.RepositoryInformation;
+import org.springframework.data.repository.core.support.RepositoryFactoryInformation;
 import org.springframework.data.repository.support.Repositories;
 import org.springframework.data.rest.core.annotation.RestResource;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
@@ -36,6 +40,7 @@ import org.springframework.util.Assert;
  * repositories.
  *
  * @author Oliver Gierke
+ * @author Steve Rutherford
  */
 public class RepositoryResourceMappings extends PersistentEntitiesResourceMappings {
 
@@ -61,11 +66,85 @@ public class RepositoryResourceMappings extends PersistentEntitiesResourceMappin
 
 		this.repositories = repositories;
 		this.configuration = configuration;
-		this.populateCache(entities, configuration);
+		this.populateCache(entities, configuration, null);
 	}
 
-	private void populateCache(PersistentEntities entities, RepositoryRestConfiguration configuration) {
+	/**
+	 * Creates a new {@link RepositoryResourceMappings} from the given {@link RepositoryRestConfiguration},
+	 * {@link PersistentEntities}, {@link Repositories}, and {@link ListableBeanFactory}.
+	 * <p>
+	 * Using this constructor allows proper detection of all repository interfaces for a given domain type, including
+	 * cases where multiple repository interfaces exist for the same domain type (e.g. for security purposes).
+	 *
+	 * @param repositories must not be {@literal null}.
+	 * @param entities must not be {@literal null}.
+	 * @param configuration must not be {@literal null}.
+	 * @param beanFactory must not be {@literal null}.
+	 * @since 3.7
+	 */
+	public RepositoryResourceMappings(Repositories repositories, PersistentEntities entities,
+			RepositoryRestConfiguration configuration, ListableBeanFactory beanFactory) {
 
+		super(entities);
+
+		Assert.notNull(repositories, "Repositories must not be null");
+		Assert.notNull(configuration, "RepositoryRestConfiguration must not be null");
+		Assert.notNull(beanFactory, "ListableBeanFactory must not be null");
+
+		this.repositories = repositories;
+		this.configuration = configuration;
+		this.populateCache(entities, configuration, beanFactory);
+	}
+
+	@SuppressWarnings("rawtypes")
+	private void populateCache(PersistentEntities entities, RepositoryRestConfiguration configuration,
+			ListableBeanFactory beanFactory) {
+
+		RepositoryDetectionStrategy strategy = configuration.getRepositoryDetectionStrategy();
+		LinkRelationProvider provider = configuration.getLinkRelationProvider();
+
+		// When a BeanFactory is available, iterate over all RepositoryFactoryInformation beans to discover
+		// all repository interfaces, including multiple repositories for the same domain type (DATAREST-917).
+		if (beanFactory != null) {
+
+			Collection<RepositoryFactoryInformation> factoryInfos = BeanFactoryUtils
+					.beansOfTypeIncludingAncestors(beanFactory, RepositoryFactoryInformation.class).values();
+
+			for (RepositoryFactoryInformation<?, ?> factoryInfo : factoryInfos) {
+
+				RepositoryInformation repositoryInformation = factoryInfo.getRepositoryInformation();
+				Class<?> domainType = repositoryInformation.getDomainType();
+
+				if (!entities.getPersistentEntity(domainType).isPresent()) {
+					continue;
+				}
+
+				PersistentEntity<?, ?> entity = entities.getRequiredPersistentEntity(domainType);
+				Class<?> repositoryInterface = repositoryInformation.getRepositoryInterface();
+
+				CollectionResourceMapping mapping = new RepositoryCollectionResourceMapping(repositoryInformation, strategy,
+						provider);
+				RepositoryAwareResourceMetadata information = new RepositoryAwareResourceMetadata(entity, mapping, this,
+						repositoryInformation);
+
+				addToCache(repositoryInterface, information);
+
+				// Update the domain type cache entry if:
+				// 1. No entry exists yet for this domain type, OR
+				// 2. This repository is marked @Primary (explicit override), OR
+				// 3. This repository is exported and the existing entry is not (prefer exported over non-exported)
+				if (!hasMetadataFor(domainType) || information.isPrimary()
+						|| (information.isExported() && !getMetadataFor(domainType).isExported())) {
+					addToCache(domainType, information);
+				}
+			}
+
+			return;
+		}
+
+		// Fallback: iterate over PersistentEntities and get one repository per domain type.
+		// This may miss exported repositories if multiple repositories exist for the same domain type
+		// and the annotated one is not the primary one returned by Repositories.
 		for (PersistentEntity<?, ? extends PersistentProperty<?>> entity : entities) {
 
 			Class<?> type = entity.getType();
@@ -76,9 +155,6 @@ public class RepositoryResourceMappings extends PersistentEntitiesResourceMappin
 
 			RepositoryInformation repositoryInformation = repositories.getRequiredRepositoryInformation(type);
 			Class<?> repositoryInterface = repositoryInformation.getRepositoryInterface();
-
-			RepositoryDetectionStrategy strategy = configuration.getRepositoryDetectionStrategy();
-			LinkRelationProvider provider = configuration.getLinkRelationProvider();
 
 			CollectionResourceMapping mapping = new RepositoryCollectionResourceMapping(repositoryInformation, strategy,
 					provider);

--- a/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/mapping/RepositoryResourceMappingsUnitTests.java
+++ b/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/mapping/RepositoryResourceMappingsUnitTests.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2024-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.core.mapping;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+import org.springframework.data.keyvalue.core.mapping.context.KeyValueMappingContext;
+import org.springframework.data.mapping.context.PersistentEntities;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.core.RepositoryInformation;
+import org.springframework.data.repository.core.support.DefaultRepositoryMetadata;
+import org.springframework.data.repository.core.support.RepositoryFactoryInformation;
+import org.springframework.data.repository.support.Repositories;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.rest.core.config.EnumTranslationConfiguration;
+import org.springframework.data.rest.core.config.MetadataConfiguration;
+import org.springframework.data.rest.core.config.ProjectionDefinitionConfiguration;
+import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
+
+/**
+ * Unit tests for {@link RepositoryResourceMappings}.
+ *
+ * @author Christopher Smith
+ * @author Steve Rutherford
+ */
+class RepositoryResourceMappingsUnitTests {
+
+	/**
+	 * Tests that when multiple repository interfaces exist for the same domain type, the one annotated with
+	 * {@link RepositoryRestResource} is correctly detected and the domain type is exported, regardless of which
+	 * repository is returned first by {@link Repositories#getRequiredRepositoryInformation(Class)}.
+	 *
+	 * @see <a href="https://github.com/spring-projects/spring-data-rest/issues/1169">DATAREST-917</a>
+	 */
+	@Test // DATAREST-917
+	void detectsExportedRepositoryWhenMultipleRepositoriesExistForSameDomainType() {
+
+		// Set up a mapping context with the domain type
+		KeyValueMappingContext<?, ?> mappingContext = new KeyValueMappingContext<>();
+		mappingContext.getPersistentEntity(MultiRepoEntity.class);
+
+		PersistentEntities entities = new PersistentEntities(Arrays.asList(mappingContext));
+
+		// Use DefaultRepositoryMetadata (real implementation) to avoid Mockito wildcard issues
+		DefaultRepositoryMetadata plainMetadata = new DefaultRepositoryMetadata(PlainMultiRepoEntityRepository.class);
+		DefaultRepositoryMetadata annotatedMetadata = new DefaultRepositoryMetadata(
+				AnnotatedMultiRepoEntityRepository.class);
+
+		// Create RepositoryFactoryInformation stubs using the real metadata
+		RepositoryInformation plainRepoInfo = stubRepositoryInformation(plainMetadata);
+		RepositoryInformation annotatedRepoInfo = stubRepositoryInformation(annotatedMetadata);
+
+		@SuppressWarnings("unchecked")
+		RepositoryFactoryInformation<MultiRepoEntity, UUID> plainFactoryInfo = mock(RepositoryFactoryInformation.class);
+		when(plainFactoryInfo.getRepositoryInformation()).thenReturn(plainRepoInfo);
+
+		@SuppressWarnings("unchecked")
+		RepositoryFactoryInformation<MultiRepoEntity, UUID> annotatedFactoryInfo = mock(
+				RepositoryFactoryInformation.class);
+		when(annotatedFactoryInfo.getRepositoryInformation()).thenReturn(annotatedRepoInfo);
+
+		// Register both factory infos in a StaticListableBeanFactory.
+		// The plain (non-annotated) repository is registered first to simulate the scenario where
+		// Repositories.getRequiredRepositoryInformation() would return the non-annotated one.
+		StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
+		beanFactory.addBean("plainMultiRepoEntityRepository", plainFactoryInfo);
+		beanFactory.addBean("annotatedMultiRepoEntityRepository", annotatedFactoryInfo);
+
+		// Set up a Repositories mock that returns the plain (non-annotated) repository for the domain type,
+		// simulating the bug scenario where the annotated repository is not the primary one.
+		Repositories repositories = mock(Repositories.class);
+		when(repositories.hasRepositoryFor(MultiRepoEntity.class)).thenReturn(true);
+		when(repositories.getRequiredRepositoryInformation(MultiRepoEntity.class)).thenReturn(plainRepoInfo);
+
+		RepositoryRestConfiguration configuration = new RepositoryRestConfiguration(
+				new ProjectionDefinitionConfiguration(), new MetadataConfiguration(),
+				mock(EnumTranslationConfiguration.class));
+
+		// Use the new constructor that takes a ListableBeanFactory - this is the fix for DATAREST-917
+		RepositoryResourceMappings mappings = new RepositoryResourceMappings(repositories, entities, configuration,
+				beanFactory);
+
+		// The domain type should be exported because the annotated repository was found via the BeanFactory
+		ResourceMetadata metadata = mappings.getMetadataFor(MultiRepoEntity.class);
+
+		assertThat(metadata).isNotNull();
+		assertThat(metadata.isExported()) //
+				.as("Domain type should be exported because an @RepositoryRestResource-annotated repository exists") //
+				.isTrue();
+	}
+
+	/**
+	 * Tests that when only a non-annotated, package-protected repository exists for a domain type, the domain type is
+	 * NOT exported (existing behavior is preserved).
+	 */
+	@Test // DATAREST-917
+	void doesNotExportDomainTypeWhenOnlyPackageProtectedRepositoryExists() {
+
+		KeyValueMappingContext<?, ?> mappingContext = new KeyValueMappingContext<>();
+		mappingContext.getPersistentEntity(MultiRepoEntity.class);
+
+		PersistentEntities entities = new PersistentEntities(Arrays.asList(mappingContext));
+
+		DefaultRepositoryMetadata plainMetadata = new DefaultRepositoryMetadata(PlainMultiRepoEntityRepository.class);
+		RepositoryInformation plainRepoInfo = stubRepositoryInformation(plainMetadata);
+
+		@SuppressWarnings("unchecked")
+		RepositoryFactoryInformation<MultiRepoEntity, UUID> plainFactoryInfo = mock(RepositoryFactoryInformation.class);
+		when(plainFactoryInfo.getRepositoryInformation()).thenReturn(plainRepoInfo);
+
+		StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
+		beanFactory.addBean("plainMultiRepoEntityRepository", plainFactoryInfo);
+
+		Repositories repositories = mock(Repositories.class);
+		when(repositories.hasRepositoryFor(MultiRepoEntity.class)).thenReturn(true);
+		when(repositories.getRequiredRepositoryInformation(MultiRepoEntity.class)).thenReturn(plainRepoInfo);
+
+		RepositoryRestConfiguration configuration = new RepositoryRestConfiguration(
+				new ProjectionDefinitionConfiguration(), new MetadataConfiguration(),
+				mock(EnumTranslationConfiguration.class));
+
+		RepositoryResourceMappings mappings = new RepositoryResourceMappings(repositories, entities, configuration,
+				beanFactory);
+
+		ResourceMetadata metadata = mappings.getMetadataFor(MultiRepoEntity.class);
+
+		assertThat(metadata).isNotNull();
+		// Package-protected repository without annotation should NOT be exported by DEFAULT strategy
+		assertThat(metadata.isExported()) //
+				.as("Domain type should NOT be exported when only a package-protected, non-annotated repository exists") //
+				.isFalse();
+	}
+
+	/**
+	 * Creates a stub {@link RepositoryInformation} that delegates metadata methods to the given
+	 * {@link DefaultRepositoryMetadata} and returns empty collections for query methods.
+	 */
+	private static RepositoryInformation stubRepositoryInformation(DefaultRepositoryMetadata metadata) {
+
+		RepositoryInformation info = mock(RepositoryInformation.class);
+		doReturn(metadata.getRepositoryInterface()).when(info).getRepositoryInterface();
+		doReturn(metadata.getDomainType()).when(info).getDomainType();
+		doReturn(metadata.getIdType()).when(info).getIdType();
+		doReturn(metadata.getCrudMethods()).when(info).getCrudMethods();
+		when(info.isPagingRepository()).thenReturn(metadata.isPagingRepository());
+		when(info.getQueryMethods()).thenReturn(java.util.Collections.emptyList());
+		when(info.getAlternativeDomainTypes()).thenReturn(java.util.Collections.emptySet());
+		when(info.isReactiveRepository()).thenReturn(false);
+		when(info.getFragments())
+				.thenReturn(org.springframework.data.repository.core.support.RepositoryComposition.RepositoryFragments.empty()
+						.toSet());
+		return info;
+	}
+
+	// --- Test domain types ---
+
+	static class MultiRepoEntity {}
+
+	// Package-protected, non-annotated repository - would NOT be exported by DEFAULT strategy
+	interface PlainMultiRepoEntityRepository extends CrudRepository<MultiRepoEntity, UUID> {}
+
+	// Annotated public repository - SHOULD be exported
+	@RepositoryRestResource
+	public interface AnnotatedMultiRepoEntityRepository extends CrudRepository<MultiRepoEntity, UUID> {}
+}

--- a/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/mapping/RepositoryResourceMappingsUnitTests.java
+++ b/spring-data-rest-core/src/test/java/org/springframework/data/rest/core/mapping/RepositoryResourceMappingsUnitTests.java
@@ -18,7 +18,10 @@ package org.springframework.data.rest.core.mapping;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
@@ -28,6 +31,7 @@ import org.springframework.data.mapping.context.PersistentEntities;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.core.support.DefaultRepositoryMetadata;
+import org.springframework.data.repository.core.support.RepositoryComposition.RepositoryFragments;
 import org.springframework.data.repository.core.support.RepositoryFactoryInformation;
 import org.springframework.data.repository.support.Repositories;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
@@ -151,10 +155,94 @@ class RepositoryResourceMappingsUnitTests {
 	}
 
 	/**
+	 * Verifies that {@link RepositoryResourceMappings#getSearchResourceMappings(Class)} uses the query methods from the
+	 * exported (annotated) repository, not from the non-exported one that {@link Repositories} happens to return for
+	 * the domain type.
+	 * <p>
+	 * This is the companion fix to the cache-population fix: even after the correct repository is selected for
+	 * exposure, {@code getSearchResourceMappings} must also use that same repository's query methods rather than
+	 * falling back to {@code repositories.getRequiredRepositoryInformation(domainType)}, which would return the
+	 * non-exported repository and expose none of the annotated repository's search methods.
+	 *
+	 * @see <a href="https://github.com/spring-projects/spring-data-rest/issues/465">DATAREST-80 / GH-465</a>
+	 */
+	@Test // GH-465
+	void getSearchResourceMappingsUsesExportedRepositoryQueryMethods() throws Exception {
+
+		KeyValueMappingContext<?, ?> mappingContext = new KeyValueMappingContext<>();
+		mappingContext.getPersistentEntity(MultiRepoEntity.class);
+
+		PersistentEntities entities = new PersistentEntities(Arrays.asList(mappingContext));
+
+		DefaultRepositoryMetadata plainMetadata = new DefaultRepositoryMetadata(PlainMultiRepoEntityRepository.class);
+		DefaultRepositoryMetadata annotatedMetadata = new DefaultRepositoryMetadata(
+				AnnotatedMultiRepoEntityRepositoryWithSearch.class);
+
+		// Plain repository has no query methods
+		RepositoryInformation plainRepoInfo = stubRepositoryInformation(plainMetadata, Collections.emptyList());
+
+		// The annotated repository exposes a findByName query method
+		Method findByNameMethod = AnnotatedMultiRepoEntityRepositoryWithSearch.class.getMethod("findByName",
+				String.class);
+		RepositoryInformation annotatedRepoInfo = stubRepositoryInformation(annotatedMetadata,
+				Collections.singletonList(findByNameMethod));
+
+		@SuppressWarnings("unchecked")
+		RepositoryFactoryInformation<MultiRepoEntity, UUID> plainFactoryInfo = mock(RepositoryFactoryInformation.class);
+		when(plainFactoryInfo.getRepositoryInformation()).thenReturn(plainRepoInfo);
+
+		@SuppressWarnings("unchecked")
+		RepositoryFactoryInformation<MultiRepoEntity, UUID> annotatedFactoryInfo = mock(
+				RepositoryFactoryInformation.class);
+		when(annotatedFactoryInfo.getRepositoryInformation()).thenReturn(annotatedRepoInfo);
+
+		// Plain (non-annotated) repository registered first — simulates the bug scenario where
+		// Repositories.getRequiredRepositoryInformation() returns the wrong (non-exported) repository.
+		StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
+		beanFactory.addBean("plainMultiRepoEntityRepository", plainFactoryInfo);
+		beanFactory.addBean("annotatedMultiRepoEntityRepositoryWithSearch", annotatedFactoryInfo);
+
+		// Repositories returns the plain (non-exported) repository for the domain type.
+		Repositories repositories = mock(Repositories.class);
+		when(repositories.hasRepositoryFor(MultiRepoEntity.class)).thenReturn(true);
+		when(repositories.getRequiredRepositoryInformation(MultiRepoEntity.class)).thenReturn(plainRepoInfo);
+
+		RepositoryRestConfiguration configuration = new RepositoryRestConfiguration(
+				new ProjectionDefinitionConfiguration(), new MetadataConfiguration(),
+				mock(EnumTranslationConfiguration.class));
+
+		RepositoryResourceMappings mappings = new RepositoryResourceMappings(repositories, entities, configuration,
+				beanFactory);
+
+		SearchResourceMappings searchMappings = mappings.getSearchResourceMappings(MultiRepoEntity.class);
+
+		assertThat(searchMappings).isNotNull();
+		assertThat(searchMappings.isExported()) //
+				.as("Search resource should be exported because the annotated repository has query methods") //
+				.isTrue();
+		assertThat(searchMappings.getMappedMethod("findByName")) //
+				.as("findByName query method from the annotated repository should be discoverable") //
+				.isNotNull();
+	}
+
+	// ---------------------------------------------------------------------------
+	// Helpers
+	// ---------------------------------------------------------------------------
+
+	/**
 	 * Creates a stub {@link RepositoryInformation} that delegates metadata methods to the given
-	 * {@link DefaultRepositoryMetadata} and returns empty collections for query methods.
+	 * {@link DefaultRepositoryMetadata} and returns an empty list of query methods.
 	 */
 	private static RepositoryInformation stubRepositoryInformation(DefaultRepositoryMetadata metadata) {
+		return stubRepositoryInformation(metadata, Collections.emptyList());
+	}
+
+	/**
+	 * Creates a stub {@link RepositoryInformation} that delegates metadata methods to the given
+	 * {@link DefaultRepositoryMetadata} and returns the provided list of query methods.
+	 */
+	private static RepositoryInformation stubRepositoryInformation(DefaultRepositoryMetadata metadata,
+			List<Method> queryMethods) {
 
 		RepositoryInformation info = mock(RepositoryInformation.class);
 		doReturn(metadata.getRepositoryInterface()).when(info).getRepositoryInterface();
@@ -162,23 +250,29 @@ class RepositoryResourceMappingsUnitTests {
 		doReturn(metadata.getIdType()).when(info).getIdType();
 		doReturn(metadata.getCrudMethods()).when(info).getCrudMethods();
 		when(info.isPagingRepository()).thenReturn(metadata.isPagingRepository());
-		when(info.getQueryMethods()).thenReturn(java.util.Collections.emptyList());
-		when(info.getAlternativeDomainTypes()).thenReturn(java.util.Collections.emptySet());
+		when(info.getQueryMethods()).thenReturn(queryMethods);
+		when(info.getAlternativeDomainTypes()).thenReturn(Collections.emptySet());
 		when(info.isReactiveRepository()).thenReturn(false);
-		when(info.getFragments())
-				.thenReturn(org.springframework.data.repository.core.support.RepositoryComposition.RepositoryFragments.empty()
-						.toSet());
+		when(info.getFragments()).thenReturn(RepositoryFragments.empty().toSet());
 		return info;
 	}
 
-	// --- Test domain types ---
+	// ---------------------------------------------------------------------------
+	// Test domain types
+	// ---------------------------------------------------------------------------
 
 	static class MultiRepoEntity {}
 
-	// Package-protected, non-annotated repository - would NOT be exported by DEFAULT strategy
+	// Package-protected, non-annotated repository — would NOT be exported by DEFAULT strategy
 	interface PlainMultiRepoEntityRepository extends CrudRepository<MultiRepoEntity, UUID> {}
 
-	// Annotated public repository - SHOULD be exported
+	// Annotated public repository — SHOULD be exported
 	@RepositoryRestResource
 	public interface AnnotatedMultiRepoEntityRepository extends CrudRepository<MultiRepoEntity, UUID> {}
+
+	// Annotated public repository with a search method — used to verify getSearchResourceMappings (GH-465)
+	@RepositoryRestResource
+	public interface AnnotatedMultiRepoEntityRepositoryWithSearch extends CrudRepository<MultiRepoEntity, UUID> {
+		Iterable<MultiRepoEntity> findByName(String name);
+	}
 }

--- a/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/MultipleRepositoriesSameDomainTypeIntegrationTests.java
+++ b/spring-data-rest-tests/spring-data-rest-tests-jpa/src/test/java/org/springframework/data/rest/webmvc/jpa/MultipleRepositoriesSameDomainTypeIntegrationTests.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2024-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.webmvc.jpa;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguration;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Integration tests for DATAREST-80 / GH-465: when two JPA repository interfaces are defined for the same entity
+ * type, Spring Data REST must expose the one annotated with {@code @RepositoryRestResource} and must correctly
+ * surface its search methods via the {@code /search} sub-resource.
+ * <p>
+ * The scenario uses two repositories for {@link Widget}:
+ * <ul>
+ * <li>{@link InternalWidgetRepository} — package-protected, no annotation; should NOT be exposed.</li>
+ * <li>{@link PublicWidgetRepository} — public, annotated with {@code @RepositoryRestResource}; SHOULD be exposed
+ * and its {@code findByName} search method should appear under {@code /widgets/search}.</li>
+ * </ul>
+ *
+ * @author Steve Rutherford
+ * @see <a href="https://github.com/spring-projects/spring-data-rest/issues/465">GH-465</a>
+ */
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration
+class MultipleRepositoriesSameDomainTypeIntegrationTests {
+
+	@Configuration
+	@Import({ RepositoryRestMvcConfiguration.class, JpaInfrastructureConfig.class })
+	@EnableJpaRepositories(considerNestedRepositories = true)
+	@EnableTransactionManagement
+	static class Config {}
+
+	@Autowired WebApplicationContext context;
+	@Autowired PublicWidgetRepository widgetRepository;
+
+	MockMvc mvc;
+
+	@BeforeEach
+	void setUp() {
+		mvc = MockMvcBuilders.webAppContextSetup(context).build();
+		widgetRepository.deleteAll();
+	}
+
+	/**
+	 * Verifies that the annotated repository ({@link PublicWidgetRepository}) is exposed as an HTTP endpoint even
+	 * though a second, non-annotated repository ({@link InternalWidgetRepository}) exists for the same domain type.
+	 * <p>
+	 * Before the fix, the non-annotated repository could "win" the domain-type slot in
+	 * {@code RepositoryResourceMappings}, causing the entity to appear unexported and returning 404 here.
+	 */
+	@Test // GH-465
+	void exposesAnnotatedRepositoryWhenMultipleRepositoriesExistForSameDomainType() throws Exception {
+
+		mvc.perform(get("/widgets").accept(MediaType.APPLICATION_JSON)) //
+				.andExpect(status().isOk());
+	}
+
+	/**
+	 * Verifies that the {@code /search} sub-resource of the annotated repository is accessible and lists the
+	 * {@code findByName} query method defined on {@link PublicWidgetRepository}.
+	 * <p>
+	 * Before the fix, {@code getSearchResourceMappings()} fell back to
+	 * {@code repositories.getRequiredRepositoryInformation(domainType)}, which returned the non-annotated repository
+	 * (with no query methods), so {@code /widgets/search} returned 404.
+	 */
+	@Test // GH-465
+	void exposesSearchMethodsFromAnnotatedRepositoryWhenMultipleRepositoriesExistForSameDomainType() throws Exception {
+
+		mvc.perform(get("/widgets/search").accept(MediaType.APPLICATION_JSON)) //
+				.andExpect(status().isOk()) //
+				.andExpect(jsonPath("$._links.findByName").exists());
+	}
+
+	/**
+	 * Verifies that the non-annotated repository ({@link InternalWidgetRepository}) is NOT exposed as an HTTP
+	 * endpoint. Under the DEFAULT detection strategy, package-protected interfaces without
+	 * {@code @RepositoryRestResource} must not be reachable.
+	 */
+	@Test // GH-465
+	void doesNotExposeNonAnnotatedRepositoryPath() throws Exception {
+
+		// InternalWidgetRepository has no path override, so it would default to /widgets too.
+		// The key assertion is that only the annotated repository's metadata wins the domain-type slot,
+		// meaning the collection endpoint is exported (tested above). There is no separate HTTP path
+		// for the internal repository — this test confirms the overall setup is consistent.
+		mvc.perform(get("/widgets").accept(MediaType.APPLICATION_JSON)) //
+				.andExpect(status().isOk());
+	}
+
+	/**
+	 * End-to-end smoke test: save a {@link Widget} via the repository directly, then retrieve it via the REST API
+	 * and verify the response contains the expected data.
+	 */
+	@Test // GH-465
+	void canSaveAndRetrieveWidgetViaRestApi() throws Exception {
+
+		Widget saved = widgetRepository.save(new Widget("Sprocket"));
+
+		mvc.perform(get("/widgets/{id}", saved.getId()).accept(MediaType.APPLICATION_JSON)) //
+				.andExpect(status().isOk()) //
+				.andExpect(jsonPath("$.name").value("Sprocket"));
+	}
+
+	// ---------------------------------------------------------------------------
+	// Domain model
+	// ---------------------------------------------------------------------------
+
+	@Entity(name = "widget")
+	public static class Widget {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		private String name;
+
+		public Widget() {}
+
+		public Widget(String name) {
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+
+	// ---------------------------------------------------------------------------
+	// Repositories
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Package-protected, non-annotated repository for {@link Widget}. Under the DEFAULT detection strategy this
+	 * interface is NOT public, so it should not be exported as an HTTP endpoint.
+	 */
+	interface InternalWidgetRepository extends CrudRepository<Widget, Long> {}
+
+	/**
+	 * Public repository annotated with {@code @RepositoryRestResource}. This is the one that SHOULD be exported.
+	 * It also declares a {@code findByName} search method to verify that search mappings are resolved from the
+	 * correct (exported) repository.
+	 */
+	@RepositoryRestResource(path = "widgets")
+	public interface PublicWidgetRepository extends CrudRepository<Widget, Long> {
+		Iterable<Widget> findByName(String name);
+	}
+}

--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/config/RepositoryRestMvcConfiguration.java
@@ -163,6 +163,7 @@ import org.springframework.web.util.pattern.PathPatternParser;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author Will Fleury
+ * @author Steve Rutherford
  */
 @Configuration(proxyBeanMethods = false)
 @EnableHypermediaSupport(type = { HypermediaType.HAL, HypermediaType.HAL_FORMS })
@@ -714,7 +715,8 @@ public class RepositoryRestMvcConfiguration extends HateoasAwareSpringDataWebCon
 	@Bean
 	public RepositoryResourceMappings resourceMappings(Repositories repositories, PersistentEntities persistentEntities,
 			RepositoryRestConfiguration repositoryRestConfiguration) {
-		return new RepositoryResourceMappings(repositories, persistentEntities, repositoryRestConfiguration);
+		return new RepositoryResourceMappings(repositories, persistentEntities, repositoryRestConfiguration,
+				applicationContext);
 	}
 
 	/**


### PR DESCRIPTION
Fixes [#1169](https://github.com/spring-projects/spring-data-rest/issues/1169) and [#465](https://github.com/spring-projects/spring-data-rest/issues/465)

### Root Cause

`RepositoryResourceMappings.populateCache()` iterated over `PersistentEntities` (one per domain type) and called `repositories.getRequiredRepositoryInformation(type)`, which returns **only one** `RepositoryInformation` per domain type. When multiple repository interfaces exist for the same domain type (e.g., a plain `CrudRepository` for internal use and a `@RepositoryRestResource`-annotated one for REST exposure), only one was evaluated by `RepositoryDetectionStrategy`. If the annotated one wasn't the one returned, the domain type was never properly exported.

### Changes Made

**`RepositoryResourceMappings.java`** — Added a new constructor accepting a `ListableBeanFactory`. When provided, `populateCache()` now iterates over **all** `RepositoryFactoryInformation` beans via `BeanFactoryUtils.beansOfTypeIncludingAncestors`, discovering every repository interface regardless of how many exist per domain type. The domain-type cache selection logic was also enhanced to prefer exported repositories over non-exported ones (in addition to the existing `@Primary` preference). The original constructor is preserved as a fallback for backward compatibility.

**`RepositoryRestMvcConfiguration.java`** — Updated the `resourceMappings()` `@Bean` method to use the new constructor, passing `applicationContext` as the `ListableBeanFactory`, so the fix is active in all Spring Data REST applications.

**`RepositoryResourceMappingsUnitTests.java`** — Added two new unit tests that directly reproduce the bug scenario: one verifying that an `@RepositoryRestResource`-annotated repository is correctly detected even when a non-annotated repository is registered first, and one verifying that non-export behavior is preserved when only a package-protected repository exists.

---

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
