### PR TITLE
Fix for @version field value ignored when updating data.

### DIFF
--- a/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/DomainObjectReader.java
+++ b/spring-data-rest-webmvc/src/main/java/org/springframework/data/rest/webmvc/json/DomainObjectReader.java
@@ -65,6 +65,7 @@ import org.springframework.util.ObjectUtils;
  * @author Mathias Düsterhöft
  * @author Thomas Mrozinski
  * @author Lars Vierbergen
+ * @author Steve Rutherford
  * @since 2.2
  */
 @SuppressWarnings("NullAway")
@@ -282,7 +283,13 @@ public class DomainObjectReader {
 
 			if (!mappedProperties.isWritableField(fieldName)) {
 
-				i.remove();
+				// Allow the version field to pass through so that the underlying store's optimistic locking
+				// mechanism can detect version mismatches (GH-1689). The id field is still stripped to
+				// prevent clients from changing the identity of the resource.
+				PersistentProperty<?> nonWritable = mappedProperties.getPersistentProperty(fieldName);
+				if (nonWritable == null || !nonWritable.isVersionProperty()) {
+					i.remove();
+				}
 				continue;
 			}
 

--- a/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/json/DomainObjectReaderUnitTests.java
+++ b/spring-data-rest-webmvc/src/test/java/org/springframework/data/rest/webmvc/json/DomainObjectReaderUnitTests.java
@@ -73,6 +73,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
  * @author Mathias Düsterhöft
  * @author Ken Dombeck
  * @author Thomas Mrozinski
+ * @author Steve Rutherford
  */
 @ExtendWith(MockitoExtension.class)
 class DomainObjectReaderUnitTests {
@@ -204,6 +205,42 @@ class DomainObjectReaderUnitTests {
 
 		assertThat(result.lastname).isEqualTo("Matthews");
 		assertThat(result.firstname).isNull();
+		assertThat(result.id).isEqualTo(1L);
+		assertThat(result.version).isEqualTo(1L);
+	}
+
+	@Test // GH-1689
+	void appliesVersionFromClientForPatch() throws Exception {
+
+		VersionedType existing = new VersionedType();
+		existing.id = 1L;
+		existing.version = 1L;
+		existing.firstname = "Dave";
+
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode node = (ObjectNode) mapper.readTree("{ \"version\" : 2, \"lastname\" : \"Matthews\" }");
+
+		VersionedType result = reader.doMerge(node, existing, mapper);
+
+		assertThat(result.lastname).isEqualTo("Matthews");
+		assertThat(result.id).isEqualTo(1L);
+		assertThat(result.version).isEqualTo(2L);
+	}
+
+	@Test // GH-1689
+	void doesNotAllowMutatingVersionViaPutBody() throws Exception {
+
+		VersionedType existing = new VersionedType();
+		existing.id = 1L;
+		existing.version = 1L;
+		existing.firstname = "Dave";
+
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode node = (ObjectNode) mapper.readTree("{ \"version\" : 9999, \"lastname\" : \"Matthews\" }");
+
+		VersionedType result = reader.readPut(node, existing, mapper);
+
+		assertThat(result.lastname).isEqualTo("Matthews");
 		assertThat(result.id).isEqualTo(1L);
 		assertThat(result.version).isEqualTo(1L);
 	}


### PR DESCRIPTION
Fixes [#1689](https://github.com/spring-projects/spring-data-rest/issues/1689)

### Root Cause

In `DomainObjectReader.doMerge()` (used for HTTP PATCH / JSON Merge Patch), the version field sent by the client was being **silently stripped** from the JSON node before Jackson applied it to the target object. This happened because `MappedJacksonProperties.isWritableField()` returns `false` for version properties, and `doMerge()` removes any non-writable field from the JSON node:

```java
if (!mappedProperties.isWritableField(fieldName)) {
    i.remove();  // ← version field was removed here
    continue;
}
```

As a result, the existing version from the database was always kept, so the underlying store's optimistic locking mechanism never saw a version mismatch — even when the client sent a wrong version number.

### Fix

**`DomainObjectReader.doMerge()`** — Instead of unconditionally removing all non-writable fields, the fix checks if the non-writable field is the version property. If it is, the field is **kept** in the JSON node so Jackson can apply it to the target object, enabling the store's optimistic locking to detect mismatches. The id field is still stripped to prevent clients from changing resource identity.

```java
if (!mappedProperties.isWritableField(fieldName)) {
    // Allow the version field to pass through so that the underlying store's optimistic locking
    // mechanism can detect version mismatches (GH-1689). The id field is still stripped to
    // prevent clients from changing the identity of the resource.
    PersistentProperty<?> nonWritable = mappedProperties.getPersistentProperty(fieldName);
    if (nonWritable == null || !nonWritable.isVersionProperty()) {
        i.remove();
    }
    continue;
}
```

### Behavior preserved

- **HTTP PUT**: `retainIdentifierAndVersion()` still overwrites the client's version with the server's version before deserialization, so PUT cannot mutate the version (existing tests `doesNotWipeIdAndVersionPropertyForPut` and `doesNotAllowMutatingIdAndVersionViaPutBody` still pass).
- **JSON Patch**: `JsonPointerMapping.forWrite()` still rejects writes to the version property via JSON Patch operations (existing test `forWriteRejectsVersionProperty` still passes).
- **HTTP PATCH (JSON Merge Patch)**: The client-provided version is now applied to the object, allowing the store to throw `OptimisticLockException` on version mismatch.

### Tests added

Two new tests in `DomainObjectReaderUnitTests`:
- `appliesVersionFromClientForPatch()` — verifies the version from the client is applied during PATCH
- `doesNotAllowMutatingVersionViaPutBody()` — verifies the version cannot be changed via PUT

---

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

